### PR TITLE
chore: add TargetRevision to GitSync 

### DIFF
--- a/api/v1/gitsync_types.go
+++ b/api/v1/gitsync_types.go
@@ -53,6 +53,10 @@ type RepositoryPath struct {
 	// Can be a file or a directory
 	// Note that all resources within this path (described by .yaml files) will be synced
 	Path string `json:"path"`
+
+	// TargetRevision specifies the target revision to sync to, it can be a branch, a tag,
+	// or a commit hash.
+	TargetRevision string `json:"targetRevision"`
 }
 
 type Destination struct {

--- a/config/crd/bases/numaplane.numaproj.io.github.com.numaproj-labs_gitsyncs.yaml
+++ b/config/crd/bases/numaplane.numaproj.io.github.com.numaproj-labs_gitsyncs.yaml
@@ -67,10 +67,15 @@ spec:
                     repoUrl:
                       description: RepoUrl is the URL to the repository itself
                       type: string
+                    targetRevision:
+                      description: TargetRevision specifies the target revision to
+                        sync to, it can be a branch, a tag, or a commit hash.
+                      type: string
                   required:
                   - name
                   - path
                   - repoUrl
+                  - targetRevision
                   type: object
                 type: array
             required:

--- a/config/samples/numaplane.numaproj.io_v1_gitsync.yaml
+++ b/config/samples/numaplane.numaproj.io_v1_gitsync.yaml
@@ -12,9 +12,11 @@ spec:
   repositoryPaths:
     - repoUrl: "https://github.com/myrepo.git"
       path: "./numaflowResources/"
+      targetRevision: "main"
       name: my-pipelines
     - repoUrl: "https://github.com/myrepo.git"
       path: "./nested/numaflowController/"
+      targetRevision: "main"
       name: controller
   destinations:
     - cluster: staging-usw2-k8s


### PR DESCRIPTION
Adding `TargetRevision` to specify the revision to sync to for a given repository path in GitSync.