### PR TITLE
Speed up the docker build with a go build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
 
+# Add a go build cache. The persistent cache helps speed up build steps,
+# especially steps that involve installing packages using a package manager.
+ENV GOCACHE=/root/.cache/go-build
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO


### PR DESCRIPTION
This PR should speed up the docker build quite a lot, especially when we have large go dependencies. With a persistent cache for packages means that even if you rebuild a layer, you only download new or changed packages instead of downloading from fresh.