### PR TITLE
chore: Fetch all remote branches for resolution 

### DIFF
--- a/api/v1/gitsync_types.go
+++ b/api/v1/gitsync_types.go
@@ -76,6 +76,7 @@ type RepositoryPath struct {
 	RepoUrl string `json:"repoUrl"`
 
 	// Path is the full path from the root of the repository to where the resources are held
+	// If Path is empty, then the root directory will be used.
 	// Can be a file or a directory
 	// Note that all resources within this path (described by .yaml files) will be synced
 	Path string `json:"path"`

--- a/config/crd/bases/numaplane.numaproj.io.github.com.numaproj-labs_gitsyncs.yaml
+++ b/config/crd/bases/numaplane.numaproj.io.github.com.numaproj-labs_gitsyncs.yaml
@@ -62,7 +62,8 @@ spec:
                       type: string
                     path:
                       description: Path is the full path from the root of the repository
-                        to where the resources are held Can be a file or a directory
+                        to where the resources are held If Path is empty, then the
+                        root directory will be used. Can be a file or a directory
                         Note that all resources within this path (described by .yaml
                         files) will be synced
                       type: string

--- a/internal/git/gitsync_processor.go
+++ b/internal/git/gitsync_processor.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
@@ -28,6 +29,11 @@ func isCommitSHA(sha string) bool {
 	return commitSHARegex.MatchString(sha)
 }
 
+// isRootDir returns whether or not this given path represents root directory of a repo
+func isRootDir(path string) bool {
+	return path == "." || path == "./" || path == "/"
+}
+
 type GitSyncProcessor struct {
 	gitSync     v1.GitSync
 	channels    map[string]chan Message
@@ -40,10 +46,22 @@ func watchRepo(ctx context.Context, repo *v1.RepositoryPath, _ /* namespace */ s
 
 	r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 		URL:          repo.RepoUrl,
-		SingleBranch: true,
+		SingleBranch: false,
 	})
 	if err != nil {
 		logger.Errorw("error cloning the repository", "err", err)
+		return err
+	}
+
+	// Fetch all remote branches
+	remote, err := r.Remote("origin")
+	if err != nil {
+		return err
+	}
+	opts := &git.FetchOptions{
+		RefSpecs: []config.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
+	}
+	if err = remote.Fetch(opts); err != nil {
 		return err
 	}
 
@@ -68,11 +86,13 @@ func watchRepo(ctx context.Context, repo *v1.RepositoryPath, _ /* namespace */ s
 		return err
 	}
 
-	// Locate the tree with the given path.
-	tree, err = tree.Tree(repo.Path)
-	if err != nil {
-		logger.Errorw("error locate the path", "err", err)
-		return err
+	if !isRootDir(repo.Path) {
+		// Locate the tree with the given path.
+		tree, err = tree.Tree(repo.Path)
+		if err != nil {
+			logger.Errorw("error locate the path", "err", err)
+			return err
+		}
 	}
 
 	// Read all the files under the path and apply each one respectively.

--- a/internal/git/gitsync_processor.go
+++ b/internal/git/gitsync_processor.go
@@ -29,9 +29,10 @@ func isCommitSHA(sha string) bool {
 	return commitSHARegex.MatchString(sha)
 }
 
-// isRootDir returns whether or not this given path represents root directory of a repo
+// isRootDir returns whether or not this given path represents root directory of a repo,
+// We consider empty string as the root.
 func isRootDir(path string) bool {
-	return path == "." || path == "./" || path == "/"
+	return len(path) == 0
 }
 
 type GitSyncProcessor struct {

--- a/internal/git/gitsync_processor_test.go
+++ b/internal/git/gitsync_processor_test.go
@@ -15,7 +15,7 @@ func Test_watchRepo(t *testing.T) {
 		hasError bool
 	}{
 		{
-			name: "branch name as a TargetRevision",
+			name: "`main` as a TargetRevision",
 			repo: v1.RepositoryPath{
 				RepoUrl:        "https://github.com/numaproj-labs/numaplane.git",
 				Path:           "config/samples",
@@ -45,16 +45,16 @@ func Test_watchRepo(t *testing.T) {
 			name: "remote branch name as a TargetRevision",
 			repo: v1.RepositoryPath{
 				RepoUrl:        "https://github.com/git-fixtures/basic.git",
-				Path:           "./",
+				Path:           "go",
 				TargetRevision: "refs/remotes/origin/branch",
 			},
 			hasError: false,
 		},
 		{
-			name: "more branch name as a TargetRevision",
+			name: "local branch name as a TargetRevision",
 			repo: v1.RepositoryPath{
 				RepoUrl:        "https://github.com/git-fixtures/basic.git",
-				Path:           ".",
+				Path:           "go",
 				TargetRevision: "branch",
 			},
 			hasError: false,
@@ -63,7 +63,7 @@ func Test_watchRepo(t *testing.T) {
 			name: "root path",
 			repo: v1.RepositoryPath{
 				RepoUrl:        "https://github.com/git-fixtures/basic.git",
-				Path:           "/",
+				Path:           "",
 				TargetRevision: "branch",
 			},
 			hasError: false,

--- a/internal/git/gitsync_processor_test.go
+++ b/internal/git/gitsync_processor_test.go
@@ -24,6 +24,15 @@ func Test_watchRepo(t *testing.T) {
 			hasError: false,
 		},
 		{
+			name: "tag name as a TargetRevision",
+			repo: v1.RepositoryPath{
+				RepoUrl:        "https://github.com/go-git/go-git.git",
+				Path:           ".github",
+				TargetRevision: "v5.5.1",
+			},
+			hasError: false,
+		},
+		{
 			name: "commit hash as a TargetRevision",
 			repo: v1.RepositoryPath{
 				RepoUrl:        "https://github.com/numaproj-labs/numaplane.git",
@@ -33,11 +42,29 @@ func Test_watchRepo(t *testing.T) {
 			hasError: false,
 		},
 		{
-			name: "tag name as a TargetRevision",
+			name: "remote branch name as a TargetRevision",
 			repo: v1.RepositoryPath{
-				RepoUrl:        "https://github.com/go-git/go-git.git",
-				Path:           ".github",
-				TargetRevision: "v5.5.1",
+				RepoUrl:        "https://github.com/git-fixtures/basic.git",
+				Path:           "./",
+				TargetRevision: "refs/remotes/origin/branch",
+			},
+			hasError: false,
+		},
+		{
+			name: "more branch name as a TargetRevision",
+			repo: v1.RepositoryPath{
+				RepoUrl:        "https://github.com/git-fixtures/basic.git",
+				Path:           ".",
+				TargetRevision: "branch",
+			},
+			hasError: false,
+		},
+		{
+			name: "root path",
+			repo: v1.RepositoryPath{
+				RepoUrl:        "https://github.com/git-fixtures/basic.git",
+				Path:           "/",
+				TargetRevision: "branch",
 			},
 			hasError: false,
 		},


### PR DESCRIPTION
This PR adds the logic to fetch all remote branches for correct `TargetRevision` resolution. It also allows root directory as repo `Path`.