### PR TITLE
default image has a new name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMAGE_FULL_PATH}
+	cd config/manager && $(KUSTOMIZE) edit set image numaplane-controller=${IMAGE_FULL_PATH}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
+- name: numaplane-controller
   newName: numaplane-controller
   newTag: latest


### PR DESCRIPTION
Running `make deploy` edits the kustomization.yaml file for the Controller to change the image name from its default to a new name. The default recently changed from "controller" to "numaplane-controller", but the call to `kustomize edit` didn't get changed.

As part of this, I'm changing the default `config/manager/kustomization.yaml` as well. This is what the file looks like if you do `make deploy` (not setting IMG or IMAGE_FULL_PATH). Note this file will change locally if we run `make deploy IMAGE_FULL_PATH=x`, so we shouldn't check in that temporary change. I thought about adding this file to .gitignore, but wasn't sure since what if we want to change the file in the future? 