### PR TITLE
allow building non-optimized code for debugging purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ VERSION ?= latest
 #IMAGE_FULL_PATH ?= $(IMAGE_NAMESPACE)/$(IMG):$(VERSION)
 IMAGE_FULL_PATH ?= $(IMG):$(VERSION)
 
+GCFLAGS="all=-N -l"
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.0
 
@@ -90,11 +92,11 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -gcflags=${GCFLAGS} -o bin/manager cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run -gcflags=${GCFLAGS} ./cmd/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
When using the debugger, sometimes one cannot print the values of certain variables, which have been "optimized" out of the binary. By specifying GCFLAGS to "all=-N -l", this won't happen. I made this the default but you can also run `GCFLAGS="" make build` if you want an optimized binary. 

I tested:
`make build`
`make run`
`GCFLAGS="" make build`
`GCFLAGS="" make run`