### PR TITLE
Avoid throw error when git remote repo has no change

### DIFF
--- a/internal/git/gitsync_processor.go
+++ b/internal/git/gitsync_processor.go
@@ -74,7 +74,7 @@ func watchRepo(ctx context.Context, r *git.Repository, gitSync *v1.GitSync, rest
 	opts := &git.FetchOptions{
 		RefSpecs: []config.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
 	}
-	if err = remote.Fetch(opts); err != nil {
+	if err = remote.Fetch(opts); err != nil && err != git.NoErrAlreadyUpToDate {
 		return err
 	}
 


### PR DESCRIPTION
Close https://github.com/numaproj-labs/numaplane/issues/62

We should not treat `git.NoErrAlreadyUpToDate` as error which simply means the remote repo has no change.