### PR TITLE
Add env variable for CLUSTER_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= numaplane-controller
 VERSION ?= latest
-# Default cluster name where pumaplane get deployed, update it as needed.
+# Default cluster name where numaplane get deployed, update it as needed.
 CLUSTER_NAME ?= "staging-usw2-k8s"
 #TODO: add back once ready to push to quay.io
 #IMAGE_NAMESPACE ?= quay.io/numaproj

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Image URL to use all building/pushing image targets
 IMG ?= numaplane-controller
 VERSION ?= latest
+# Default cluster name where pumaplane get deployed, update it as needed.
+CLUSTER_NAME ?= "staging-usw2-k8s"
 #TODO: add back once ready to push to quay.io
 #IMAGE_NAMESPACE ?= quay.io/numaproj
 #IMAGE_FULL_PATH ?= $(IMAGE_NAMESPACE)/$(IMG):$(VERSION)
@@ -141,7 +143,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image numaplane-controller=${IMAGE_FULL_PATH}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/default | sed 's/CLUSTER_NAME_VALUE/$(CLUSTER_NAME)/g' | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
         - --leader-elect
         env:
           - name: CLUSTER_NAME
-            value: CLUSTER_NAME_VALUE
+            value: CLUSTER_NAME_VALUE # Replace it with the cluster name where numaplane will get deployed.
         image: numaplane-controller:latest
         name: manager
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        env:
+          - name: CLUSTER_NAME
+            value: CLUSTER_NAME_VALUE
         image: numaplane-controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
Deployed controller specs

```bash
macos-P9DJ3XY0QL :: github.com/numaproj-labs/numaplane ‹cluster-name-env*› » k get deploy numaplane-controller-manager -n numaplane-system -o yaml

      ......
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      - args:
        - --health-probe-bind-address=:8081
        - --metrics-bind-address=127.0.0.1:8080
        - --leader-elect
        command:
        - /manager
        env:
        - name: CLUSTER_NAME
          value: staging-usw2-k8s
        image: numaplane-controller:latest
        imagePullPolicy: Always
      .....
```