### PR TITLE
[Do Not Merge] feat: resources tracking with annotation

### DIFF
--- a/internal/kubernates/kubernate.go
+++ b/internal/kubernates/kubernate.go
@@ -1,0 +1,49 @@
+package kubernates
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// GetGitSyncInstanceAnnotation returns the application instance name from annotation
+func GetGitSyncInstanceAnnotation(un *unstructured.Unstructured, key string) (string, error) {
+	annotations, _, err := nestedNullableStringMap(un.Object, "metadata", "annotations")
+	if err != nil {
+		return "", fmt.Errorf("failed to get annotations from target object %s %s/%s: %w", un.GroupVersionKind().String(), un.GetNamespace(), un.GetName(), err)
+	}
+	if annotations != nil {
+		return annotations[key], nil
+	}
+	return "", nil
+}
+
+// SetGitSyncInstanceAnnotation the recommended app.kubernetes.io/instance annotation against an unstructured object
+// Uses the legacy labeling if environment variable is set
+func SetGitSyncInstanceAnnotation(target *unstructured.Unstructured, key, val string) error {
+	annotations, _, err := nestedNullableStringMap(target.Object, "metadata", "annotations")
+	if err != nil {
+		return fmt.Errorf("failed to get annotations from target object %s %s/%s: %w", target.GroupVersionKind().String(), target.GetNamespace(), target.GetName(), err)
+	}
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[key] = val
+	target.SetAnnotations(annotations)
+	return nil
+}
+
+// nestedNullableStringMap returns a copy of map[string]string value of a nested field.
+// Returns false if value is not found and an error if not one of map[string]interface{} or nil, or contains non-string values in the map.
+func nestedNullableStringMap(obj map[string]interface{}, fields ...string) (map[string]string, bool, error) {
+	var m map[string]string
+	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil {
+		return nil, found, err
+	}
+	if found && val != nil {
+		return unstructured.NestedStringMap(obj, fields...)
+	}
+	return m, found, err
+}

--- a/internal/kubernates/kubernate_test.go
+++ b/internal/kubernates/kubernate_test.go
@@ -1,0 +1,38 @@
+package kubernates
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/numaproj-labs/numaplane/internal/shared"
+)
+
+func TestGetGitSyncInstanceAnnotation(t *testing.T) {
+	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
+	assert.Nil(t, err)
+	var obj unstructured.Unstructured
+	err = yaml.Unmarshal(yamlBytes, &obj)
+	assert.Nil(t, err)
+	err = SetGitSyncInstanceAnnotation(&obj, shared.AnnotationKeyGitSyncInstance, "my-gitsync")
+	assert.Nil(t, err)
+
+	annotation, err := GetGitSyncInstanceAnnotation(&obj, shared.AnnotationKeyGitSyncInstance)
+	assert.Nil(t, err)
+	assert.Equal(t, "my-gitsync", annotation)
+}
+
+func TestGetGitSyncInstanceAnnotationWithInvalidData(t *testing.T) {
+	yamlBytes, err := os.ReadFile("testdata/svc-with-invalid-data.yaml")
+	assert.Nil(t, err)
+	var obj unstructured.Unstructured
+	err = yaml.Unmarshal(yamlBytes, &obj)
+	assert.Nil(t, err)
+
+	_, err = GetGitSyncInstanceAnnotation(&obj, "valid-annotation")
+	assert.Error(t, err)
+	assert.Equal(t, "failed to get annotations from target object /v1, Kind=Service /my-service: .metadata.annotations accessor error: contains non-string key in the map: <nil> is of the type <nil>, expected string", err.Error())
+}

--- a/internal/shared/common.go
+++ b/internal/shared/common.go
@@ -1,0 +1,6 @@
+package shared
+
+const (
+	// AnnotationKeyGitSyncInstance Resource metadata annotations (keys and values) used for tracking
+	AnnotationKeyGitSyncInstance = "numaplane.numaproj.io/tracking-id"
+)


### PR DESCRIPTION


Fixes https://github.com/numaproj-labs/numaplane/issues/112

### Modifications

Use `numaplane.numaproj.io/tracking-id` annotation to track resources. This PR contains the utility to do that.



### Verification

Unit test.

Note this PR is only for reference ATM. It needs to be merged together with the other automated syncing refactor PRs.
