### PR TITLE
Add support for deploy helm chart repo

### DIFF
--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -1,22 +1,27 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/numaproj-labs/numaplane/api/v1alpha1"
-	"github.com/numaproj-labs/numaplane/internal/kustomize"
-	"github.com/numaproj-labs/numaplane/internal/shared/logging"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/numaproj-labs/numaplane/api/v1alpha1"
 	controllerConfig "github.com/numaproj-labs/numaplane/internal/controller/config"
+	"github.com/numaproj-labs/numaplane/internal/helm"
+	"github.com/numaproj-labs/numaplane/internal/kustomize"
 	gitShared "github.com/numaproj-labs/numaplane/internal/shared/git"
+	"github.com/numaproj-labs/numaplane/internal/shared/logging"
 )
 
 func CloneRepo(
@@ -60,22 +65,49 @@ func GetLatestManifests(
 		return manifests, err
 	}
 
-	// Only create the resources for the first time if not created yet.
-	// Otherwise, monitoring with intervals.
-
-	// kustomizePath will be the path of clone repository + the path where kustomize file is present.
 	localRepoPath := getLocalRepoPath(gitSync.GetName())
-	kustomizePath := localRepoPath + "/" + gitSync.Spec.Path
-	k := kustomize.NewKustomizeApp(kustomizePath, gitSync.Spec.RepoUrl, os.Getenv("KUSTOMIZE_BINARY_PATH"))
 
-	if kustomize.IsKustomizationRepository(kustomizePath) {
-		m, err := k.Build(nil)
+	// repoPath will be the path of clone repository + the path while needs to be deployed.
+	deployablePath := localRepoPath + "/" + gitSync.Spec.Path
+	// validate the deployablePath path for its existence.
+	if _, err := os.Stat(deployablePath); err != nil {
+		return manifests, fmt.Errorf("invalid deployable path, err: %v", err)
+	}
+
+	// initialize the kustomize with KUSTOMIZE_BINARY_PATH if defined.
+	k := kustomize.NewKustomizeApp(deployablePath, gitSync.Spec.RepoUrl, os.Getenv("KUSTOMIZE_BINARY_PATH"))
+
+	// initialize the helm with HELM_BINARY_PATH if defined.
+	h := helm.New(deployablePath, os.Getenv("HELM_BINARY_PATH"))
+
+	sourceType, err := gitSync.Spec.ExplicitType()
+	if err != nil {
+		return manifests, err
+	}
+
+	switch sourceType {
+	case v1alpha1.SourceTypeKustomize:
+		generatedManifest, err := k.Build(nil)
 		if err != nil {
-			logger.Errorw("cannot build kustomize yaml", "err", err)
+			logger.Errorw("can not build kustomize yaml", "err", err)
 			return manifests, err
 		}
-		manifests = append(manifests, m...)
-	} else {
+		manifestData, err := SplitYAMLToString([]byte(generatedManifest))
+		if err != nil {
+			return manifests, fmt.Errorf("can not parse kustomize manifest, err: %v", err)
+		}
+		manifests = append(manifests, manifestData...)
+	case v1alpha1.SourceTypeHelm:
+		generatedManifest, err := h.Build(gitSync.Name, gitSync.Spec.Destination.Namespace, gitSync.Spec.Helm.Parameters, gitSync.Spec.Helm.ValueFiles)
+		if err != nil {
+			return manifests, fmt.Errorf("cannot build helm manifest, err: %v", err)
+		}
+		manifestData, err := SplitYAMLToString([]byte(generatedManifest))
+		if err != nil {
+			return manifests, fmt.Errorf("can not parse helm manifest, err: %v", err)
+		}
+		manifests = append(manifests, manifestData...)
+	case v1alpha1.SourceTypeRaw:
 		// Retrieving the commit object matching the hash.
 		tree, err := getCommitTreeAtPath(r, gitSync.Spec.Path, *hash)
 		if err != nil {
@@ -84,13 +116,16 @@ func GetLatestManifests(
 		// Read all the files under the path and apply each one respectively.
 		err = tree.Files().ForEach(func(f *object.File) error {
 			logger.Debugw("read file", "file_name", f.Name)
-			// TODO: this currently assumes that one file contains just one manifest - modify for multiple
 			manifest, err := f.Contents()
 			if err != nil {
 				logger.Errorw("cannot get file content", "filename", f.Name, "err", err)
 				return err
 			}
-			manifests = append(manifests, manifest)
+			manifestData, err := SplitYAMLToString([]byte(manifest))
+			if err != nil {
+				return fmt.Errorf("can not parse file data, err: %v", err)
+			}
+			manifests = append(manifests, manifestData...)
 			return nil
 		})
 		if err != nil {
@@ -199,4 +234,26 @@ func cloneRepo(
 	}
 
 	return r, err
+}
+
+// SplitYAMLToString splits a YAML file into strings. Returns list of yamls
+// found in the yaml. If an error occurs, returns objects that have been parsed so far too.
+func SplitYAMLToString(yamlData []byte) ([]string, error) {
+	d := kubeyaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlData), 4096)
+	var objs []string
+	for {
+		ext := runtime.RawExtension{}
+		if err := d.Decode(&ext); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return objs, fmt.Errorf("failed to unmarshal manifest: %v", err)
+		}
+		ext.Raw = bytes.TrimSpace(ext.Raw)
+		if len(ext.Raw) == 0 || bytes.Equal(ext.Raw, []byte("null")) {
+			continue
+		}
+		objs = append(objs, string(ext.Raw))
+	}
+	return objs, nil
 }

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -162,12 +162,34 @@ func Test_GetLatestManifests(t *testing.T) {
 		},
 		{
 			name: "manifest from kustomize enabled repo",
-			gitSync: newGitSync(
-				"kustomizeManifest",
-				"https://github.com/numaproj/numaflow.git",
-				"config/namespace-install",
-				"main",
-			),
+			gitSync: &v1alpha1.GitSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      "kustomize-manifest",
+				},
+				Spec: v1alpha1.GitSyncSpec{
+					RepoUrl:        "https://github.com/numaproj/numaflow.git",
+					TargetRevision: "main",
+					Path:           "config/namespace-install",
+					Kustomize:      &v1alpha1.KustomizeSource{},
+				},
+			},
+			hasErr: false,
+		},
+		{
+			name: "manifest from helm enabled repo",
+			gitSync: &v1alpha1.GitSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      "helm-manifest",
+				},
+				Spec: v1alpha1.GitSyncSpec{
+					RepoUrl:        "https://github.com/numaproj/helm-charts.git",
+					TargetRevision: "main",
+					Path:           "charts/numaflow",
+					Helm:           &v1alpha1.HelmSource{},
+				},
+			},
 			hasErr: false,
 		},
 	}

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -1,0 +1,78 @@
+package helm
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/numaproj-labs/numaplane/api/v1alpha1"
+	numaExec "github.com/numaproj-labs/numaplane/internal/shared/exec"
+)
+
+var (
+	re = regexp.MustCompile(`([^\\]),`)
+)
+
+type helm struct {
+	binaryPath           string
+	chartPath            string
+	templateNameArg      string
+	showCommand          string
+	pullCommand          string
+	kubeVersionSupported bool
+}
+
+func New(chartPath, binaryPath string) Helm {
+	return &helm{
+		binaryPath:           binaryPath,
+		chartPath:            chartPath,
+		templateNameArg:      "--name-template",
+		kubeVersionSupported: true,
+		showCommand:          "show",
+		pullCommand:          "pull",
+	}
+}
+
+// Helm provides wrapper functionality around the `helm` command.
+type Helm interface {
+	// Build returns a list of yaml string from a `helm template` command
+	Build(string, string, []v1alpha1.HelmParameter, []string) (string, error)
+}
+
+func (h *helm) getBinaryPath() string {
+	if h.binaryPath != "" {
+		return h.binaryPath
+	}
+	return "helm"
+}
+
+func (h *helm) Build(name, namespace string, parameters []v1alpha1.HelmParameter, values []string) (string, error) {
+	args := []string{"template", h.chartPath, h.templateNameArg, name}
+
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	for _, parameter := range parameters {
+		args = append(args, "--set", parameter.Name+"="+cleanSetParameters(parameter.Value))
+	}
+	for _, val := range values {
+		args = append(args, "--values", val)
+	}
+
+	cmd := exec.Command(h.getBinaryPath(), args...)
+
+	out, err := numaExec.Run(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	return out, nil
+}
+
+func cleanSetParameters(val string) string {
+	// `{}` equal helm list parameters format, so don't escape `,`.
+	if strings.HasPrefix(val, `{`) && strings.HasSuffix(val, `}`) {
+		return val
+	}
+	return re.ReplaceAllString(val, `$1\,`)
+}

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -22,7 +22,7 @@ import (
 // Kustomize provides wrapper functionality around the `kustomize` command.
 type Kustomize interface {
 	// Build returns a list of unstructured objects from a `kustomize build` command and extract supported parameters
-	Build(kustomizeOptions *KustomizeOptions) ([]string, error)
+	Build(kustomizeOptions *KustomizeOptions) (string, error)
 }
 
 type kustomize struct {
@@ -60,7 +60,7 @@ func (k *kustomize) getBinaryPath() string {
 	return "kustomize"
 }
 
-func (k *kustomize) Build(kustomizeOptions *KustomizeOptions) ([]string, error) {
+func (k *kustomize) Build(kustomizeOptions *KustomizeOptions) (string, error) {
 	var cmd *exec.Cmd
 	if kustomizeOptions != nil && kustomizeOptions.BuildOptions != "" {
 		params := parseKustomizeBuildOptions(k.path, kustomizeOptions.BuildOptions)
@@ -71,15 +71,10 @@ func (k *kustomize) Build(kustomizeOptions *KustomizeOptions) ([]string, error) 
 
 	out, err := numaExec.Run(cmd)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	manifests, err := splitYAMLToString([]byte(out))
-	if err != nil {
-		return nil, err
-	}
-
-	return manifests, nil
+	return out, nil
 }
 
 func parseKustomizeBuildOptions(path, buildOptions string) []string {

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -1,16 +1,10 @@
 package kustomize
 
 import (
-	"bytes"
-	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	numaExec "github.com/numaproj-labs/numaplane/internal/shared/exec"
 )
@@ -92,26 +86,4 @@ func IsKustomizationRepository(path string) bool {
 	}
 
 	return false
-}
-
-// SplitYAMLToString splits a YAML file into strings. Returns list of yamls
-// found in the yaml. If an error occurs, returns objects that have been parsed so far too.
-func splitYAMLToString(yamlData []byte) ([]string, error) {
-	d := kubeyaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlData), 4096)
-	var objs []string
-	for {
-		ext := runtime.RawExtension{}
-		if err := d.Decode(&ext); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return objs, fmt.Errorf("failed to unmarshal manifest: %v", err)
-		}
-		ext.Raw = bytes.TrimSpace(ext.Raw)
-		if len(ext.Raw) == 0 || bytes.Equal(ext.Raw, []byte("null")) {
-			continue
-		}
-		objs = append(objs, string(ext.Raw))
-	}
-	return objs, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #110 #128

### Modifications

Add support to deploy helm chart repo in kubernetes cluster

<!-- TODO: Say what changes you made (including any design decisions) -->

**GitSync spec used for an example**

```yaml
apiVersion: numaplane.numaproj.io/v1alpha1
kind: GitSync
metadata:
  name: gitsync-example
  namespace: numaplane-system
spec:
  path: charts/numaflow
  repoUrl: https://github.com/numaproj/helm-charts.git
  targetRevision: main
  helm: {}
  destination:
    cluster: staging-usw2-k8s
    namespace: numaflow-pipeline
```


### Verification

Tested manually in local environment

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

