### PR TITLE
fix: remove name field from GitSync sample, which no longer exists

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
@@ -4,7 +4,6 @@ metadata:
   name: gitsync-example
   namespace: numaplane-system
 spec:
-  name: user-repo
   path: sample-pipeline
   repoUrl: https://github.com/xdevxy/numaflow-example-pipelines.git
   targetRevision: main


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

GitSync CRD no longer contains a "name" field in it, so needed to remove it from the sample GitSync.


### Verification

successfully deployed the GitSync sample

