### PR TITLE
Ownership Reference to Kubernetes resources

### DIFF
--- a/internal/git/gitsync_processor_test.go
+++ b/internal/git/gitsync_processor_test.go
@@ -1067,3 +1067,227 @@ func TestGitCloneRepoHTTPSWithLocalGitServer(t *testing.T) {
 	assert.NoError(t, err)
 
 }
+
+func TestApplyOwnerShipReference(t *testing.T) {
+	resource := `apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+  namespace: numaflow
+spec:
+  containers:
+    - name: app
+      image: images.my-company.example/app:v4
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+    - name: log-aggregator
+      image: images.my-company.example/log-aggregator:v6
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+        limits:
+          memory: "128Mi"
+          cpu: "500m"`
+
+	gitsync := &v1alpha1.GitSync{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GitSync",
+			APIVersion: "1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "gitsync-test", UID: "awew"},
+		Spec:       v1alpha1.GitSyncSpec{},
+		Status:     v1alpha1.GitSyncStatus{},
+	}
+	reference, err := ApplyOwnershipReference(resource, gitsync)
+	log.Println(string(reference))
+	assert.Equal(t, `apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  name: frontend
+  namespace: numaflow
+  ownerReferences:
+  - apiVersion: "1"
+    blockOwnerDeletion: true
+    controller: true
+    kind: GitSync
+    name: gitsync-test
+    uid: awew
+spec:
+  containers:
+  - image: images.my-company.example/app:v4
+    name: app
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 250m
+        memory: 64Mi
+  - image: images.my-company.example/log-aggregator:v6
+    name: log-aggregator
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 250m
+        memory: 64Mi
+status: {}
+`, string(reference))
+	assert.NoError(t, err)
+
+}
+
+func TestApplyOwnerShipReferenceAppendExisting(t *testing.T) {
+	resource := `apiVersion: v1
+kind: Pod
+metadata:
+  name: my-custom-resource
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: my-deployment
+    uid: <uid-of-my-deployment>
+    controller: false
+    blockOwnerDeletion: true
+  - apiVersion: v1
+    kind: ConfigMap
+    name: my-configmap
+    uid: <uid-of-my-configmap>
+    controller: false
+    blockOwnerDeletion: true
+`
+
+	gitsync := &v1alpha1.GitSync{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GitSync",
+			APIVersion: "1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "gitsync-test", UID: "awew"},
+		Spec:       v1alpha1.GitSyncSpec{},
+		Status:     v1alpha1.GitSyncStatus{},
+	}
+	reference, err := ApplyOwnershipReference(resource, gitsync)
+	log.Println(string(reference))
+	assert.Equal(t, `apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  name: my-custom-resource
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: false
+    kind: Deployment
+    name: my-deployment
+    uid: <uid-of-my-deployment>
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: false
+    kind: ConfigMap
+    name: my-configmap
+    uid: <uid-of-my-configmap>
+  - apiVersion: "1"
+    blockOwnerDeletion: true
+    controller: true
+    kind: GitSync
+    name: gitsync-test
+    uid: awew
+spec:
+  containers: null
+status: {}
+`, string(reference))
+	assert.NoError(t, err)
+
+}
+
+func TestApplyOwnerShipReferenceJSON(t *testing.T) {
+	resource := `{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "nginx-deployment"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "replicas": 2,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx:1.14.2",
+            "ports": [
+              {
+                "containerPort": 80
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}`
+
+	gitsync := &v1alpha1.GitSync{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GitSync",
+			APIVersion: "1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "gitsync-test", UID: "awew"},
+		Spec:       v1alpha1.GitSyncSpec{},
+		Status:     v1alpha1.GitSyncStatus{},
+	}
+	reference, err := ApplyOwnershipReference(resource, gitsync)
+	log.Println(string(reference))
+	assert.Equal(t, `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: nginx-deployment
+  ownerReferences:
+  - apiVersion: "1"
+    blockOwnerDeletion: true
+    controller: true
+    kind: GitSync
+    name: gitsync-test
+    uid: awew
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx:1.14.2
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: {}
+status: {}
+`, string(reference))
+	assert.NoError(t, err)
+
+}

--- a/internal/shared/kubernetes/kubernetes.go
+++ b/internal/shared/kubernetes/kubernetes.go
@@ -2,6 +2,8 @@ package kubernetes
 
 import (
 	"regexp"
+	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -14,4 +16,10 @@ func IsValidKubernetesNamespace(name string) bool {
 		return true
 	}
 	return false
+}
+
+func IsValidKubernetesManifestFile(fileName string) bool {
+	fileExt := strings.Split(fileName, ".")
+	validExtName := []string{"yaml", "yml", "json"}
+	return slices.Contains(validExtName, fileExt[1])
 }

--- a/internal/shared/kubernetes/kubernetes_test.go
+++ b/internal/shared/kubernetes/kubernetes_test.go
@@ -1,6 +1,10 @@
 package kubernetes
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestIsValidKubernetesNamespace(t *testing.T) {
 	testCases := []struct {
@@ -28,4 +32,49 @@ func TestIsValidKubernetesNamespace(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsValidKubernetesManifestFile(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		resourceName string
+		expected     bool
+	}{
+		{
+			name:         "Invalid Name",
+			resourceName: "data.md",
+			expected:     false,
+		},
+
+		{
+			name:         "valid name",
+			resourceName: "my.yml",
+			expected:     true,
+		},
+
+		{
+			name:         "Valid Json file",
+			resourceName: "pipeline.json",
+			expected:     true,
+		},
+
+		{
+			name:         "Valid name yaml",
+			resourceName: "pipeline.yaml",
+			expected:     true,
+		},
+		{
+			name:         "Invalid File",
+			resourceName: "main.go",
+			expected:     false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok := IsValidKubernetesManifestFile(tc.resourceName)
+			assert.Equal(t, tc.expected, ok)
+		})
+	}
+
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Yes

Fixes 
https://github.com/numaproj-labs/numaplane/issues/65
https://github.com/numaproj-labs/numaplane/issues/58

### Modifications
The [ApplyOwnerShipReference](https://github.com/numaproj-labs/numaplane/blob/ownerReference/internal/git/gitsync_processor.go#L283) function in  takes a Kubernetes resource manifest in string format and a GitSync object as inputs

It creates an OwnerReference object using the properties from the GitSync object (like APIVersion, Kind, Name, UID) and sets this as the owner reference of the deserialized Kubernetes object coming from git files if it doesn't exists ,if it exists then it appends to the existing ownership object

Also it validates the valid manifests file with [IsValidKubernetesManifestFile](https://github.com/numaproj-labs/numaplane/blob/ownerReference/internal/shared/kubernetes/kubernetes.go#L21)
### Verification

Unit tests for ApplyOwnerShipReference has been tested for both [json](https://github.com/numaproj-labs/numaplane/blob/ownerReference/internal/git/gitsync_processor_test.go#L1211) and [yaml](https://github.com/numaproj-labs/numaplane/blob/ownerReference/internal/git/gitsync_processor_test.go#L1071) based files .

