### PR TITLE
chore: use repository path as part of local repo store location

### DIFF
--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -56,7 +56,7 @@ func Test_cloneRepo(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync.Name)
+			localRepoPath := getLocalRepoPath(tc.gitSync)
 			err := os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{
@@ -201,7 +201,7 @@ func Test_GetLatestManifests(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync.Name)
+			localRepoPath := getLocalRepoPath(tc.gitSync)
 			err := os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #134

### Modifications

This PR use repository path as part of local repo store location. With it, GitSync.Name + GitSync.RepositoryURL will be used to uniquely identify a clone path, so that after a GitSync RepositoryURL changes, we can clone to a new location.


### Verification
Unit Test

Also ensures updates to a GitSync CR are handled correctly by testing the following in a local cluster,

1.  `kubectl apply` the following GitSync spec,

```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: GitSync
metadata:
  name: gitsync-example
  namespace: numaplane-system
spec:
  path: config/namespace-install
  repoUrl: https://github.com/numaproj/numaflow.git
  targetRevision: main
  kustomize: {}
  destination:
    cluster: staging-usw2-k8s
    names
```
2. ensure the resources are deployed successful,
3. `kubectl apply` the changed GitSync spec,
```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: GitSync
metadata:
  name: gitsync-example
  namespace: numaplane-system
spec:
  path: sample-pipeline
  repoUrl: https://github.com/xdevxy/numaflow-example-pipelines.git
  targetRevision: main
  raw: {}
  destination:
    cluster: staging-usw2-k8s
    namespace: numaflow-pipeline-example
```
4. ensures the newly added resources are deployed successful, changed resources are applied, and deleted resources are removed.