### PR TITLE
Fix the kustomize and helm dependency and remote changes sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,13 @@ RUN curl --retry 3 --silent --location --remote-name https://get.helm.sh/helm-${
     mkdir -p /tmp/helm && tar -C /tmp/helm -xf helm-${HELM_VERSION}-linux-amd64.tar.gz && \
     install -m 0755 /tmp/helm/linux-amd64/helm /usr/local/bin/helm
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Use alpine as minimal base image to package the manager binary
+FROM alpine
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
-USER 65532:65532
+
+RUN apk add --no-cache git
 
 ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,8 +56,6 @@ spec:
       #             operator: In
       #             values:
       #               - linux
-      securityContext:
-        runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -59,6 +59,9 @@ func (h *helm) Build(name, namespace string, parameters []v1alpha1.HelmParameter
 		args = append(args, "--values", val)
 	}
 
+	// fetch and update helm dependencies if any.
+	args = append(args, "--dependency-update")
+
 	cmd := exec.Command(h.getBinaryPath(), args...)
 
 	out, err := numaExec.Run(cmd)

--- a/internal/shared/exec/exec.go
+++ b/internal/shared/exec/exec.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultTimeout = 10 * time.Second
+	defaultTimeout = 90 * time.Second
 )
 
 func Run(cmd *exec.Cmd) (string, error) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #100 

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

- Generate manifest from remote repo if referenced inside configuration of Kustomize/Helm
- Sync the changes if there is any change in remote reference, because manifest is generated each time based on latest changes from reference


### Verification

Tested it on local cluster with below below GitSync CR

For kustomize
```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: GitSync
metadata:
  name: gitsync-example
  namespace: numaplane-system
spec:
  path: kustmize-remote-example
  repoUrl: https://github.com/chandankumar4/numaplane-sample.git
  targetRevision: main
  kustomize: {}
  destination:
    cluster: staging-usw2-k8s
    namespace: numaflow-pipeline
``` 

For Helm
```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: GitSync
metadata:
  name: gitsync-example
  namespace: numaplane-system
spec:
  path: helm-dependency
  repoUrl: https://github.com/argoproj/argocd-example-apps.git
  targetRevision: master
  helm: {}
  destination:
    cluster: staging-usw2-k8s
    namespace: numaflow-pipeline
```

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

