### PR TITLE
filtering yaml and json files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/numaproj-labs/numaplane
 go 1.21
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.10.1
 	github.com/argoproj/gitops-engine v0.7.1-0.20240124052710-5fd9f449e757
 	github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1
 	github.com/bombsimon/logrusr/v2 v2.0.1
@@ -123,8 +122,6 @@ require (
 	golang.org/x/tools v0.17.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
-	google.golang.org/grpc v1.59.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj/argo-cd/v2 v2.10.1 h1:VD06GPeoq14Bo7IfiW+EKim3T1C9xaMElVrEtw+zll0=
-github.com/argoproj/argo-cd/v2 v2.10.1/go.mod h1:SK1uGZ9xWVzxuyg079MaO6+hz/Oz9wSDkGyT0gEkYSs=
 github.com/argoproj/gitops-engine v0.7.1-0.20240124052710-5fd9f449e757 h1:5fKAhTQcTBom0vin56cz/UTPx2GMuvdb+lJRAUOPbHA=
 github.com/argoproj/gitops-engine v0.7.1-0.20240124052710-5fd9f449e757/go.mod h1:gWE8uROi7hIkWGNAVM+8FWkMfo0vZ03SLx/aFw/DBzg=
 github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1 h1:qsHwwOJ21K2Ao0xPju1sNuqphyMnMYkyB3ZLoLtxWpo=
@@ -573,8 +571,6 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f h1:ultW7fxlIvee4HYrtnaRPon9HpEgFk5zYpmfMgtKB5I=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f/go.mod h1:L9KNLi232K1/xB6f7AlSX692koaRnKaWSR0stBki0Yc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -582,8 +578,6 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.59.0 h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=
-google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/numaproj-labs/numaplane/internal/helm"
 	"github.com/numaproj-labs/numaplane/internal/kustomize"
 	gitShared "github.com/numaproj-labs/numaplane/internal/shared/git"
+	kubernetesshared "github.com/numaproj-labs/numaplane/internal/shared/kubernetes"
 	"github.com/numaproj-labs/numaplane/internal/shared/logging"
 )
 
@@ -118,16 +119,19 @@ func GetLatestManifests(
 		// Read all the files under the path and apply each one respectively.
 		err = tree.Files().ForEach(func(f *object.File) error {
 			logger.Debugw("read file", "file_name", f.Name)
-			manifest, err := f.Contents()
-			if err != nil {
-				logger.Errorw("cannot get file content", "filename", f.Name, "err", err)
-				return err
+			if kubernetesshared.IsValidKubernetesManifestFile(f.Name) {
+				manifest, err := f.Contents()
+				if err != nil {
+					logger.Errorw("cannot get file content", "filename", f.Name, "err", err)
+					return err
+				}
+				manifestData, err := SplitYAMLToString([]byte(manifest))
+				if err != nil {
+					return fmt.Errorf("can not parse file data, err: %v", err)
+				}
+				manifests = append(manifests, manifestData...)
 			}
-			manifestData, err := SplitYAMLToString([]byte(manifest))
-			if err != nil {
-				return fmt.Errorf("can not parse file data, err: %v", err)
-			}
-			manifests = append(manifests, manifestData...)
+
 			return nil
 		})
 		if err != nil {

--- a/internal/shared/kubernetes/kubernetes.go
+++ b/internal/shared/kubernetes/kubernetes.go
@@ -81,5 +81,5 @@ func GetSecret(ctx context.Context, client k8sClient.Client, namespace, secretNa
 func IsValidKubernetesManifestFile(fileName string) bool {
 	fileExt := strings.Split(fileName, ".")
 	validExtName := []string{"yaml", "yml", "json"}
-	return slices.Contains(validExtName, fileExt[1])
+	return slices.Contains(validExtName, fileExt[len(fileExt)-1])
 }

--- a/internal/shared/kubernetes/kubernetes.go
+++ b/internal/shared/kubernetes/kubernetes.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -74,4 +76,10 @@ func GetSecret(ctx context.Context, client k8sClient.Client, namespace, secretNa
 		return nil, err
 	}
 	return secret, nil
+}
+
+func IsValidKubernetesManifestFile(fileName string) bool {
+	fileExt := strings.Split(fileName, ".")
+	validExtName := []string{"yaml", "yml", "json"}
+	return slices.Contains(validExtName, fileExt[1])
 }

--- a/internal/shared/kubernetes/kubernetes_test.go
+++ b/internal/shared/kubernetes/kubernetes_test.go
@@ -110,6 +110,11 @@ func TestIsValidKubernetesManifestFile(t *testing.T) {
 			resourceName: "main.go",
 			expected:     false,
 		},
+		{
+			name:         "Invalid File",
+			resourceName: "main..json.go",
+			expected:     false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/shared/kubernetes/kubernetes_test.go
+++ b/internal/shared/kubernetes/kubernetes_test.go
@@ -96,6 +96,16 @@ func TestIsValidKubernetesManifestFile(t *testing.T) {
 			expected:     true,
 		},
 		{
+			name:         "Valid name yaml",
+			resourceName: "pipeline.xyz.yaml",
+			expected:     true,
+		},
+		{
+			name:         "Valid name yaml",
+			resourceName: "pipeline.xyz.hjk.json",
+			expected:     true,
+		},
+		{
 			name:         "Invalid File",
 			resourceName: "main.go",
 			expected:     false,

--- a/internal/shared/kubernetes/kubernetes_test.go
+++ b/internal/shared/kubernetes/kubernetes_test.go
@@ -64,3 +64,48 @@ func TestGetGitSyncInstanceAnnotationWithInvalidData(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "failed to get annotations from target object /v1, Kind=Service /my-service: .metadata.annotations accessor error: contains non-string key in the map: <nil> is of the type <nil>, expected string", err.Error())
 }
+
+func TestIsValidKubernetesManifestFile(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		resourceName string
+		expected     bool
+	}{
+		{
+			name:         "Invalid Name",
+			resourceName: "data.md",
+			expected:     false,
+		},
+
+		{
+			name:         "valid name",
+			resourceName: "my.yml",
+			expected:     true,
+		},
+
+		{
+			name:         "Valid Json file",
+			resourceName: "pipeline.json",
+			expected:     true,
+		},
+
+		{
+			name:         "Valid name yaml",
+			resourceName: "pipeline.yaml",
+			expected:     true,
+		},
+		{
+			name:         "Invalid File",
+			resourceName: "main.go",
+			expected:     false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok := IsValidKubernetesManifestFile(tc.resourceName)
+			assert.Equal(t, tc.expected, ok)
+		})
+	}
+
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Fixes https://github.com/numaproj-labs/numaplane/issues/58

### Modifications

[IsValidKubernetesManifestFile](https://github.com/numaproj-labs/numaplane/blob/feat/filterYamlfiles/internal/shared/kubernetes/kubernetes.go#L81) function has been added which checks for the valid yaml and json files in the syncing repo from Gitsync CRD

### Verification

Unit tests have been written for the above [method](https://github.com/numaproj-labs/numaplane/blob/feat/filterYamlfiles/internal/shared/kubernetes/kubernetes_test.go#L68) 

This function tests the `IsValidKubernetesManifestFile` method to ensure it correctly identifies valid Kubernetes manifest file names. It checks multiple file names with different extensions (`.md`, `.yml`, `.json`, `.yaml`, `.go`) and verifies whether the method accurately classifies each as either a valid Kubernetes manifest (true) or not (false), based on their file extensions.
