### PR TITLE
Fix the build issue for slice package

### DIFF
--- a/internal/util/kubernetes/kubernetes.go
+++ b/internal/util/kubernetes/kubernetes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// validManifestExtensions contains the supported extension for raw file.
+var validManifestExtensions = map[string]struct{}{"yaml": {}, "yml": {}, "json": {}}
 
 func IsValidKubernetesNamespace(name string) bool {
 	// All namespace names must be valid RFC 1123 DNS labels.
@@ -80,6 +82,8 @@ func GetSecret(ctx context.Context, client k8sClient.Client, namespace, secretNa
 
 func IsValidKubernetesManifestFile(fileName string) bool {
 	fileExt := strings.Split(fileName, ".")
-	validExtName := []string{"yaml", "yml", "json"}
-	return slices.Contains(validExtName, fileExt[len(fileExt)-1])
+	if _, ok := validManifestExtensions[fileExt[len(fileExt)-1]]; ok {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #NONE

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->
Fix the error occured during build related to `Slice` package
```
$ make docker-build
------
 > [builder  9/11] RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o manager cmd/main.go:
0.449 internal/util/kubernetes/kubernetes.go:7:2: package slices is not in GOROOT (/usr/local/go/src/slices)
0.449 note: imported by a module that requires go 1.21
------
Dockerfile:29
--------------------
```


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->
Validated via running unit test for the same

