### PR TITLE
OwnerShip Reference to kubernetest manifests

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
@@ -4,8 +4,8 @@ metadata:
   name: gitsync-example
   namespace: numaplane-system
 spec:
-  path: sample-pipeline
-  repoUrl: https://github.com/xdevxy/numaflow-example-pipelines.git
+  path: ""
+  repoUrl: https://github.com/shubhamdixit863/yamlrepo
   targetRevision: main
   raw: {}
   destination:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
@@ -4,8 +4,8 @@ metadata:
   name: gitsync-example
   namespace: numaplane-system
 spec:
-  path: ""
-  repoUrl: https://github.com/shubhamdixit863/yamlrepo
+  path: sample-pipeline
+  repoUrl: https://github.com/xdevxy/numaflow-example-pipelines.git
   targetRevision: main
   raw: {}
   destination:

--- a/internal/util/kubernetes/kubernetes.go
+++ b/internal/util/kubernetes/kubernetes.go
@@ -116,14 +116,16 @@ func ApplyGitSyncOwnership(manifest string, gitSync *v1alpha1.GitSync) ([]byte, 
 	gitSyncNamespace := gitSync.Namespace
 
 	// Get the namespace of the object we are setting ownership on
-	objectNamespace, found, err := unstructured.NestedString(obj.Object, "metadata", "namespace")
+	// Second variable is ignored which check whether the namespace key exists in the object or not
+	// TODO :// take some action when namespace key is not present in object may be modify  the object and add namespace field ?
+	objectNamespace, _, err := unstructured.NestedString(obj.Object, "metadata", "namespace")
 	if err != nil {
 		return nil, err
 	}
 
 	// Check if they are in the same namespace
 	if gitSyncNamespace != objectNamespace {
-		return nil, fmt.Errorf("GitSync object and the resource must be in the same namespace Gitsync namespace -%s objectNamespace - %s", gitSync.Namespace, objectNamespace)
+		return nil, fmt.Errorf("GitSync object and the resource must be in the same namespace")
 	}
 
 	// Construct the new owner reference

--- a/internal/util/kubernetes/kubernetes.go
+++ b/internal/util/kubernetes/kubernetes.go
@@ -112,6 +112,19 @@ func ApplyGitSyncOwnership(manifest string, gitSync *v1alpha1.GitSync) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
+	// Get the namespace of the GitSync Object
+	gitSyncNamespace := gitSync.Namespace
+
+	// Get the namespace of the object we are setting ownership on
+	objectNamespace, found, err := unstructured.NestedString(obj.Object, "metadata", "namespace")
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if they are in the same namespace
+	if gitSyncNamespace != objectNamespace {
+		return nil, fmt.Errorf("GitSync object and the resource must be in the same namespace Gitsync namespace -%s objectNamespace - %s", gitSync.Namespace, objectNamespace)
+	}
 
 	// Construct the new owner reference
 	ownerRef := map[string]interface{}{

--- a/internal/util/kubernetes/kubernetes_test.go
+++ b/internal/util/kubernetes/kubernetes_test.go
@@ -133,38 +133,34 @@ func TestIsValidKubernetesManifestFile(t *testing.T) {
 }
 
 func TestApplyOwnerShipReference(t *testing.T) {
-	resource := `apiVersion: v1
-kind: Pod
+	resource := `apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: frontend
-  namespace: numaflow
+  name: testing-deployment
+  labels:
+    app: testing-server
 spec:
-  containers:
-    - name: app
-      image: images.my-company.example/app:v4
-      resources:
-        requests:
-          memory: "64Mi"
-          cpu: "250m"
-        limits:
-          memory: "128Mi"
-          cpu: "500m"
-    - name: log-aggregator
-      image: images.my-company.example/log-aggregator:v6
-      resources:
-        requests:
-          memory: "64Mi"
-          cpu: "250m"
-        limits:
-          memory: "128Mi"
-          cpu: "500m"`
+  replicas: 2
+  selector:
+    matchLabels:
+      app: testing-server
+  template:
+    metadata:
+      labels:
+        app: testing-server
+    spec:
+      containers:
+      - name: http-server
+        image: nginx:latest
+        ports:
+        - containerPort: 80`
 
 	gitsync := &v1alpha1.GitSync{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "GitSync",
-			APIVersion: "1",
+			APIVersion: "numaplane.numaproj.io/v1alpha1",
 		},
-		ObjectMeta: metav1.ObjectMeta{Name: "gitsync-test", UID: "awew"},
+		ObjectMeta: metav1.ObjectMeta{Name: "gitsync-test", UID: "12345678-abcd-1234-ef00-1234567890ab"},
 		Spec:       v1alpha1.GitSyncSpec{},
 		Status:     v1alpha1.GitSyncStatus{},
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Fixes  https://github.com/numaproj-labs/numaplane/issues/65

### Modifications

[ApplyOwnershipReference](https://github.com/numaproj-labs/numaplane/blob/feat/ownerRef/internal/util/kubernetes/kubernetes.go#L107), method has been added and called in the [syncer.go](https://github.com/numaproj-labs/numaplane/blob/feat/ownerRef/internal/sync/syncer.go#L219) to apply the ownership reference to kubernetes manisfests


### Verification
Running  syncer on local cluster  adds the ownership  reference to the resources

 Deletion of the related resource if gitsync gets deleted .Created a  deployment which had  said gitsync as owner deleting gitsync deleted the deployment along with all the pods created.

Unit tests Have been added to check for both yaml and json mainfests
Three cases have been covered adding the ownership reference to
1- yaml
2- json
3- Updating the existing ownership reference

For Yaml
 [ApplyOwnershipReference](https://github.com/numaproj-
labs/numaplane/blob/feat/ownerRef/internal/shared/kubernetes/kubernetes_test.go#L71) has been added to check if ownership reference gets applied for yaml
And 
For [Json](https://github.com/numaproj-labs/numaplane/blob/feat/ownerRef/internal/shared/kubernetes/kubernetes_test.go#L211) 

These unit tests checks  if the method correctly adds  an ownerReferences field to a Kubernetes Deployment resource, indicating ownership by a GitSync custom resource. The test verifies the modified resource string and asserts there are no errors.

For  Updating the existing ownership [reference](https://github.com/numaproj-labs/numaplane/blob/feat/ownerRef/internal/shared/kubernetes/kubernetes_test.go#L148) -

This function tests the `ApplyOwnershipReference` method to ensure it correctly appends an ownership reference to an existing list of owner references in a Kubernetes Pod resource. It verifies that the GitSync custom resource is added without affecting existing owner references and checks that the modified resource string is correct, asserting no errors.




