### PR TITLE
Add configuration for enabling auto heal

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,12 +92,23 @@ func main() {
 		logger.Fatalw("Failed to load config file", zap.Error(err))
 	}
 
+	config, err := configManager.GetConfig()
+	if err != nil {
+		logger.Fatalw("Failed to get config", zap.Error(err))
+	}
+	interval := config.AutoHealTimeIntervalMs
+	// If auto healing is not enabled, use the automated syncing
+	// interval instead.
+	if interval == 0 {
+		interval = config.SyncTimeIntervalMs
+	}
 	kubectl := kubernetes.NewKubectl()
 	syncer := sync.NewSyncer(
 		mgr.GetClient(),
 		mgr.GetConfig(),
 		mgr.GetConfig(),
-		kubectl)
+		kubectl,
+		sync.WithTaskInterval(interval))
 	// Add syncer runner
 	if err = mgr.Add(LeaderElectionRunner(syncer.Start)); err != nil {
 		logger.Fatalw("Unable to add autoscaling runner", zap.Error(err))

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -390,7 +390,8 @@ subjects:
 apiVersion: v1
 data:
   config.yaml: |
-    timeIntervalSec: 60
+    syncTimeIntervalMs: 60000
+    autoHealTimeIntervalMs: 30000
 kind: ConfigMap
 metadata:
   name: numaplane-controller-config

--- a/config/manager/controller-config.yaml
+++ b/config/manager/controller-config.yaml
@@ -5,4 +5,5 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    timeIntervalSec: 60
+    syncTimeIntervalMs: 60000
+    autoHealTimeIntervalMs: 30000

--- a/config/samples/config_map.yaml
+++ b/config/samples/config_map.yaml
@@ -7,7 +7,8 @@ metadata:
 data:
   config.yaml: |
     clusterName: "CLUSTER_NAME_VALUE" # Replace with the cluster name where numaplane will get deployed.
-    timeIntervalSec: 60
+    syncTimeIntervalMs: 60000
+    autoHealTimeIntervalMs: 30000
     repoCredentials:
       - url: "github.com/numaproj-labs"
         httpCredential:

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -33,8 +33,9 @@ func GetConfigManagerInstance() *ConfigManager {
 // supposed to be populated from the configmap attached to the
 // controller manager.
 type GlobalConfig struct {
-	ClusterName     string `json:"clusterName" mapstructure:"clusterName"`
-	TimeIntervalSec uint   `json:"timeIntervalSec" mapstructure:"timeIntervalSec"`
+	ClusterName            string `json:"clusterName" mapstructure:"clusterName"`
+	SyncTimeIntervalMs     int    `json:"syncTimeIntervalMs" mapstructure:"syncTimeIntervalMs"`
+	AutoHealTimeIntervalMs int    `json:"autoHealTimeIntervalMs" mapstructure:"autoHealTimeIntervalMs"`
 	// RepoCredentials maps each Git Repository Path prefix to the corresponding credentials that are needed for it
 	RepoCredentials []apiv1.RepoCredential `json:"repoCredentials" mapstructure:"repoCredentials"`
 }

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -29,7 +29,8 @@ func TestLoadConfigMatchValues(t *testing.T) {
 	assert.Nil(t, err, "Failed to load configuration")
 
 	assert.Equal(t, "staging-usw2-k8s", config.ClusterName, "ClusterName does not match")
-	assert.Equal(t, uint(60), config.TimeIntervalSec, "TimeIntervalSec does not match")
+	assert.Equal(t, 60000, config.SyncTimeIntervalMs, "SyncTimeIntervalMs does not match")
+	assert.Equal(t, 30000, config.AutoHealTimeIntervalMs, "AutoHealTimeIntervalMs does not match")
 
 	assert.NotNil(t, config.RepoCredentials, "RepoCredentials should not be nil")
 
@@ -69,7 +70,7 @@ func TestLoadConfigMatchValues(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "staging-usw2-k8s", config.ClusterName, "ClusterName does not match")
-	assert.Equal(t, uint(60), config.TimeIntervalSec, "TimeIntervalSec does not match")
+	assert.Equal(t, 60000, config.SyncTimeIntervalMs, "SyncTimeIntervalMs does not match")
 	assert.Len(t, config.RepoCredentials, 0, "RepoCredentials should not be present")
 
 }
@@ -176,8 +177,8 @@ func TestGetConfigManagerInstanceSingleton(t *testing.T) {
 
 func TestCloneWithSerialization(t *testing.T) {
 	original := &GlobalConfig{
-		ClusterName:     "testCluster",
-		TimeIntervalSec: 60,
+		ClusterName:        "testCluster",
+		SyncTimeIntervalMs: 60000,
 		RepoCredentials: []apiv1.RepoCredential{
 			{
 				URL: "repo1",
@@ -227,8 +228,8 @@ func TestCloneWithSerialization(t *testing.T) {
 
 func createGlobalConfigForBenchmarking() *GlobalConfig {
 	return &GlobalConfig{
-		ClusterName:     "testCluster",
-		TimeIntervalSec: 60,
+		ClusterName:        "testCluster",
+		SyncTimeIntervalMs: 60000,
 		RepoCredentials: []apiv1.RepoCredential{
 			{
 				URL: "repo1",

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -50,7 +50,13 @@ func KeyOfGitSync(gitSync *v1alpha1.GitSync) string {
 }
 
 // NewSyncer returns a Synchronizer instance.
-func NewSyncer(client client.Client, config *rest.Config, rawConfig *rest.Config, kubectl kubeUtil.Kubectl, opts ...Option) *Syncer {
+func NewSyncer(
+	client client.Client,
+	config *rest.Config,
+	rawConfig *rest.Config,
+	kubectl kubeUtil.Kubectl,
+	opts ...Option,
+) *Syncer {
 	watcherOpts := defaultOptions()
 	for _, opt := range opts {
 		if opt != nil {
@@ -261,7 +267,7 @@ func (s *Syncer) sync(
 
 	// If the live state match the target state, then skip the syncing.
 	if !modified {
-		logger.Info("GitSync object is successfully already synced, skip the syncing.")
+		logger.Info("GitSync object is already synced, skip the syncing.")
 		return gitopsSyncCommon.OperationSucceeded, ""
 	}
 
@@ -386,7 +392,7 @@ func updateCommitStatus(
 	}
 	currentCommitStatus := gitSync.Status.CommitStatus
 	// Skip the commit status update if the content are the same.
-	if currentCommitStatus.Synced == commitStatus.Synced &&
+	if currentCommitStatus != nil && currentCommitStatus.Synced == commitStatus.Synced &&
 		currentCommitStatus.Hash == commitStatus.Hash &&
 		currentCommitStatus.Error == commitStatus.Error {
 		return nil

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -1,5 +1,6 @@
 clusterName: "staging-usw2-k8s"
-timeIntervalSec: 60
+syncTimeIntervalMs: 60000
+autoHealTimeIntervalMs: 30000
 repoCredentials:
   - url: "github.com/numaproj-labs"
     httpCredential:

--- a/tests/config/testconfig2.yaml
+++ b/tests/config/testconfig2.yaml
@@ -1,2 +1,3 @@
 clusterName: "staging-usw2-k8s"
-timeIntervalSec: 60
+syncTimeIntervalMs: 60000
+autoHealTimeIntervalMs: 30000

--- a/tests/manifests/config.yaml
+++ b/tests/manifests/config.yaml
@@ -1,5 +1,6 @@
 clusterName: "staging-usw2-k8s"
-timeIntervalSec: 60
+syncTimeIntervalMs: 60000
+autoHealTimeIntervalMs: 30000
 repoCredentials:
 - url: "github.com/numaproj-labs"
   httpCredential:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #73

### Modifications

This PR adds the configuration for auto heal. By default, the auto heal is enabled with configurable intervals to verifying the cluster states match with the git state.


### Verification

Unit test, also verified in a local cluster.

