### PR TITLE
fix: broken Dockerfile, missing pkg path after api dir was moved/dele…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ issues:
   # restore some of the defaults
   # (fill in the rest as needed)
   exclude-rules:
-    - path: "api/*"
+    - path: "pkg/apis/*"
       linters:
         - lll
     - path: "internal/*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
-COPY api/ api/
+COPY pkg/ pkg/
 COPY internal/ internal/
 
 # Add a go build cache. The persistent cache helps speed up build steps,


### PR DESCRIPTION
This PR solves the following bugs:
- docker build was failing due to missing `api` dir since it was moved under `pkg/apis`
- upgraded `controller-gen` from `v0.13.0` to `v0.14.0` to resolve tests failure on local env
