### PR TITLE
fix race condition

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -78,10 +78,13 @@ func (cm *ConfigManager) LoadConfig(onErrorReloading func(error), configPath, co
 	if err != nil {
 		return fmt.Errorf("failed to load configuration file. %w", err)
 	}
-
-	err = v.Unmarshal(cm.config)
-	if err != nil {
-		return fmt.Errorf("failed unmarshal configuration file. %w", err)
+	{
+		cm.lock.Lock()
+		defer cm.lock.Unlock()
+		err = v.Unmarshal(cm.config)
+		if err != nil {
+			return fmt.Errorf("failed unmarshal configuration file. %w", err)
+		}
 	}
 	v.OnConfigChange(func(e fsnotify.Event) {
 		cm.lock.Lock()

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -59,9 +59,13 @@ func (cm *ConfigManager) LoadConfig(onErrorReloading func(error), configPath, co
 	if err != nil {
 		return fmt.Errorf("failed to load configuration file. %w", err)
 	}
-	err = v.Unmarshal(cm.config)
-	if err != nil {
-		return fmt.Errorf("failed unmarshal configuration file. %w", err)
+	{
+		cm.lock.Lock()
+		defer cm.lock.Unlock()
+		err = v.Unmarshal(cm.config)
+		if err != nil {
+			return fmt.Errorf("failed unmarshal configuration file. %w", err)
+		}
 	}
 	v.OnConfigChange(func(e fsnotify.Event) {
 		cm.lock.Lock()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #173 

### Modifications

To be honest, [this](https://github.com/numaproj-labs/numaplane/actions/runs/8393633134/job/22989032641) race condition captured in `go test -race` doesn't make sense. 

Supposedly, [this](https://github.com/numaproj-labs/numaplane/blob/main/internal/controller/config/config.go#L74) line in `v.OnConfigChange`'s function was called, and the "previous" call according to the CI which touched cm.config was [here](https://github.com/numaproj-labs/numaplane/blob/main/internal/controller/config/config.go#L62). (In my mind it is truly "previous" and not "concurrent", so I'm not sure what "go test -race" means by "previous" but I'm guessing it means "concurrent")

I don't think the function passed to `v.OnConfigChange()` should be invoked until [v.WatchConfig()](https://github.com/numaproj-labs/numaplane/blob/main/internal/controller/config/config.go#L76) occurs, which it calls [here](https://github.com/spf13/viper/blob/8ac644165cf967d7d5be0cb149eb321c4c8ecfcf/viper.go#L484). 

Nevertheless, I have added the lock to the code because it doesn't hurt anything to do so, and have run the CI in this PR many times with no errors.

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

