### PR TITLE
Added log level in confi

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -50,10 +50,12 @@ func main() {
 	if err != nil {
 		numaLogger.Fatal(err, "Failed to get configuration file")
 	}
+
+	numaLogger.SetLevel(config.LogLevel)
+
 	numaLogger.Infof("config: %+v", config)
 
 	// create a new AgentSyncer
 	syncer := agent.NewAgentSyncer(&numaLogger)
 	syncer.Run(ctx)
-
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -96,6 +96,9 @@ func main() {
 	if err != nil {
 		numaLogger.Fatal(err, "Failed to get config")
 	}
+
+	numaLogger.SetLevel(config.LogLevel)
+
 	interval := config.AutoHealTimeIntervalMs
 	// If auto healing is not enabled, use the automated syncing
 	// interval instead.

--- a/internal/agent/agent_syncer.go
+++ b/internal/agent/agent_syncer.go
@@ -100,6 +100,9 @@ func (syncer *AgentSyncer) checkConfigUpdate() bool {
 			return false
 		}
 		syncer.configRevision = newRevision
+
+		syncer.numaLogger.SetLevel(syncer.config.LogLevel)
+
 		return true
 	}
 	return false

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -29,8 +29,8 @@ import (
 type AgentConfig struct {
 	ClusterName     string `mapstructure:"clusterName"`
 	TimeIntervalSec uint   `mapstructure:"timeIntervalSec"`
-
-	Source Source `mapstructure:"source"`
+	Source          Source `mapstructure:"source"`
+	LogLevel        int    `mapstructure:"logLevel"`
 }
 
 type Source struct {

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -38,6 +38,7 @@ type GlobalConfig struct {
 	AutoHealTimeIntervalMs int    `json:"autoHealTimeIntervalMs" mapstructure:"autoHealTimeIntervalMs"`
 	// RepoCredentials maps each Git Repository Path prefix to the corresponding credentials that are needed for it
 	RepoCredentials []apiv1.RepoCredential `json:"repoCredentials" mapstructure:"repoCredentials"`
+	LogLevel        int                    `json:"logLevel" mapstructure:"logLevel"`
 }
 
 func (cm *ConfigManager) GetConfig() (GlobalConfig, error) {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -214,6 +214,9 @@ func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 	if err != nil {
 		numaLogger.Error(err, "error getting  the  global config")
 	}
+
+	numaLogger.SetLevel(globalConfig.LogLevel)
+
 	repo, err := git.CloneRepo(ctx, s.client, gitSync, globalConfig)
 	if err != nil {
 		return fmt.Errorf("failed to clone the repo of key %q, %w", key, err)

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -35,22 +35,22 @@ Log Level Mapping:
 */
 
 const (
-	fatalLevel   = 0
-	warnLevel    = 1
-	infoLevel    = 2
-	debugLevel   = 3
-	verboseLevel = 4
+	FatalLevel   = 0
+	WarnLevel    = 1
+	InfoLevel    = 2
+	DebugLevel   = 3
+	VerboseLevel = 4
 )
 
 var logrVerbosityToZerologLevelMap = map[int]zerolog.Level{
-	fatalLevel:   4,
-	warnLevel:    2,
-	infoLevel:    1,
-	debugLevel:   0,
-	verboseLevel: -2,
+	FatalLevel:   4,
+	WarnLevel:    2,
+	InfoLevel:    1,
+	DebugLevel:   0,
+	VerboseLevel: -2,
 }
 
-const defaultLevel = infoLevel
+const defaultLevel = InfoLevel
 
 type loggerKey struct{}
 
@@ -92,7 +92,7 @@ func newNumaLogger(writer *io.Writer, level *int) NumaLogger {
 	zerolog.CallerMarshalFunc = zerologCallerMarshalFunc
 
 	// Set zerolog global level to the most verbose level
-	zerolog.SetGlobalLevel(logrVerbosityToZerologLevelMap[verboseLevel])
+	zerolog.SetGlobalLevel(logrVerbosityToZerologLevelMap[VerboseLevel])
 
 	w := io.Writer(os.Stdout)
 	if writer != nil {
@@ -105,7 +105,7 @@ func newNumaLogger(writer *io.Writer, level *int) NumaLogger {
 	}
 
 	zl := zerolog.New(w)
-	zl = setLoggerLevel(zl, lvl).
+	zl = setLoggerLevel(&zl, lvl).
 		With().
 		Caller().
 		Timestamp().
@@ -168,7 +168,7 @@ func (nl NumaLogger) Errorf(err error, msg string, args ...any) {
 // Fatal logs an error with a message and optional key/value pairs. Then, exits with code 1.
 func (nl NumaLogger) Fatal(err error, msg string, keysAndValues ...any) {
 	keysAndValues = append(keysAndValues, "error", err)
-	nl.LogrLogger.V(fatalLevel).Info(msg, keysAndValues...)
+	nl.LogrLogger.V(FatalLevel).Info(msg, keysAndValues...)
 	os.Exit(1)
 }
 
@@ -179,7 +179,7 @@ func (nl NumaLogger) Fatalf(err error, msg string, args ...any) {
 
 // Warn logs a warning-level message with optional key/value pairs.
 func (nl NumaLogger) Warn(msg string, keysAndValues ...any) {
-	nl.LogrLogger.V(warnLevel).Info(msg, keysAndValues...)
+	nl.LogrLogger.V(WarnLevel).Info(msg, keysAndValues...)
 }
 
 // Warn logs a warning-level formatted message with args.
@@ -189,7 +189,7 @@ func (nl NumaLogger) Warnf(msg string, args ...any) {
 
 // Info logs an info-level message with optional key/value pairs.
 func (nl NumaLogger) Info(msg string, keysAndValues ...any) {
-	nl.LogrLogger.V(infoLevel).Info(msg, keysAndValues...)
+	nl.LogrLogger.V(InfoLevel).Info(msg, keysAndValues...)
 }
 
 // Infof logs an info-level formatted message with args.
@@ -199,7 +199,7 @@ func (nl NumaLogger) Infof(msg string, args ...any) {
 
 // Debug logs a debug-level message with optional key/value pairs.
 func (nl NumaLogger) Debug(msg string, keysAndValues ...any) {
-	nl.LogrLogger.V(debugLevel).Info(msg, keysAndValues...)
+	nl.LogrLogger.V(DebugLevel).Info(msg, keysAndValues...)
 }
 
 // Debugf logs a debug-level formatted message with args.
@@ -209,12 +209,19 @@ func (nl NumaLogger) Debugf(msg string, args ...any) {
 
 // Verbose logs a verbose-level message with optional key/value pairs.
 func (nl NumaLogger) Verbose(msg string, keysAndValues ...any) {
-	nl.LogrLogger.V(verboseLevel).Info(msg, keysAndValues...)
+	nl.LogrLogger.V(VerboseLevel).Info(msg, keysAndValues...)
 }
 
 // Verbosef logs a verbose-level formatted message with args.
 func (nl NumaLogger) Verbosef(msg string, args ...any) {
 	nl.WithCallDepth(1).Verbose(fmt.Sprintf(msg, args...))
+}
+
+// SetLevel sets/changes the log level.
+func (nl *NumaLogger) SetLevel(level int) {
+	sink := nl.LogrLogger.GetSink().(*LogSink)
+	zl := setLoggerLevel(sink.l, level)
+	sink.l = &zl
 }
 
 // Init receives optional information about the logr library
@@ -286,14 +293,14 @@ func (ls LogSink) WithCallDepth(depth int) logr.LogSink {
 }
 
 // setLoggerLevel sets the zerolog log level based on the given logr.Logger verbosity.
-func setLoggerLevel(logger zerolog.Logger, level int) zerolog.Logger {
+func setLoggerLevel(logger *zerolog.Logger, level int) zerolog.Logger {
 	return logger.Level(logrVerbosityToZerologLevelMap[level])
 }
 
 // zerologLevelFieldMarshalFunc adds a way to convert a custom zerolog.Level values to strings.
 func zerologLevelFieldMarshalFunc(lvl zerolog.Level) string {
 	switch lvl {
-	case logrVerbosityToZerologLevelMap[verboseLevel]:
+	case logrVerbosityToZerologLevelMap[VerboseLevel]:
 		return "verbose"
 	}
 	return lvl.String()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Added a LogLevel field to global and agent config structs to be able to load the log level from configmap. The log level is updated every time the config is retrieved again in case the level was changed in configmap.


### Verification

Manually tested by inspecting the logs.

