### PR TITLE
chore: Setup the cluster cache to only watch required resources

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -114,7 +114,7 @@ func main() {
 		sync.WithTaskInterval(interval))
 	// Add syncer runner
 	if err = mgr.Add(LeaderElectionRunner(syncer.Start)); err != nil {
-		numaLogger.Fatal(err, "Unable to add autoscaling runner")
+		numaLogger.Fatal(err, "Unable to add syncer runner")
 	}
 	reconciler, err := controller.NewGitSyncReconciler(
 		mgr.GetClient(),

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -346,9 +346,37 @@ metadata:
   name: numaplane-role
 rules:
 - apiGroups:
-  - '*'
+  - numaflow.numaproj.io
   resources:
   - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - numaplane.numaproj.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - namespaces
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
   verbs:
   - '*'
 ---

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -38,6 +38,7 @@ type GlobalConfig struct {
 	SyncTimeIntervalMs     int    `json:"syncTimeIntervalMs" mapstructure:"syncTimeIntervalMs"`
 	CascadeDeletion        bool   `json:"cascadeDeletion" mapstructure:"cascadeDeletion"`
 	AutoHealTimeIntervalMs int    `json:"autoHealTimeIntervalMs" mapstructure:"autoHealTimeIntervalMs"`
+	IncludedResources      string `json:"includedResources" mapstructure:"includedResources"`
 	// RepoCredentials maps each Git Repository Path prefix to the corresponding credentials that are needed for it
 	RepoCredentials []apiv1.RepoCredential `json:"repoCredentials" mapstructure:"repoCredentials"`
 	LogLevel        int                    `json:"logLevel" mapstructure:"logLevel"`

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -33,6 +33,12 @@ func TestLoadConfigMatchValues(t *testing.T) {
 	assert.Equal(t, 60000, config.SyncTimeIntervalMs, "SyncTimeIntervalMs does not match")
 	assert.Equal(t, 30000, config.AutoHealTimeIntervalMs, "AutoHealTimeIntervalMs does not match")
 	assert.Equal(t, false, config.CascadeDeletion, "CascadeDeletion Field does not match")
+	assert.Equal(t, "group=apps,kind=Deployment;"+
+		"group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;"+
+		"group=numaflow.numaproj.io,kind=;"+
+		"group=numaflow.numaproj.io,kind=;"+
+		"group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role",
+		config.IncludedResources, "IncludedResources does not match")
 
 	assert.NotNil(t, config.RepoCredentials, "RepoCredentials should not be nil")
 

--- a/internal/sync/cache.go
+++ b/internal/sync/cache.go
@@ -166,7 +166,7 @@ func (c *liveStateCache) getCluster() clustercache.ClusterCache {
 		}
 
 		// TODO: when switch to change event triggering for sync tasking, notify
-		//       the GitSync managing the includedResources that there are changes happen
+		//       the GitSync managing the resources that there are changes happen
 	})
 
 	c.cluster = clusterCache

--- a/internal/sync/cache_test.go
+++ b/internal/sync/cache_test.go
@@ -199,3 +199,62 @@ metadata:
 		kube.NewResourceKey("apps", "Deployment", "default", "my-app"): mustToUnstructured(testDeploy()),
 	}, managedObjs)
 }
+
+func TestParseResourceFilter(t *testing.T) {
+	testCases := []struct {
+		name              string
+		rules             string
+		expectedResources []ResourceType
+		hasErr            bool
+	}{
+		{
+			name:  "valid rules",
+			rules: "group=apps,kind=Deployment;group=rbac.authorization.k8s.io,kind=RoleBinding",
+			expectedResources: []ResourceType{
+				{
+					Group: "apps",
+					Kind:  "Deployment",
+				},
+				{
+					Group: "rbac.authorization.k8s.io",
+					Kind:  "RoleBinding",
+				},
+			},
+			hasErr: false,
+		},
+		{
+			name:  "valid rules with empty group",
+			rules: "group=apps,kind=Deployment;group=,kind=ConfigMap",
+			expectedResources: []ResourceType{
+				{
+					Group: "apps",
+					Kind:  "Deployment",
+				},
+				{
+					Group: "",
+					Kind:  "ConfigMap",
+				},
+			},
+			hasErr: false,
+		},
+		{
+			name:   "invalid rules",
+			rules:  "group=apps,kind=Deployment;grup=,kind=ConfigMap",
+			hasErr: true,
+		},
+	}
+	t.Parallel()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resources, err := parseResourceFilter(tc.rules)
+			if tc.hasErr {
+				assert.NotNil(t, err)
+				assert.Nil(t, resources)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expectedResources, *resources)
+			}
+		})
+	}
+}

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -136,7 +136,7 @@ func NewIgnoreNormalizer(overrides map[string]ResourceOverride) (diff.Normalizer
 	return &ignoreNormalizer{patches: patches}, nil
 }
 
-// Normalize removes fields from supplied resource using json paths from matching items of specified resources ignored differences list
+// Normalize removes fields from supplied resource using json paths from matching items of specified includedResources ignored differences list
 func (n *ignoreNormalizer) Normalize(un *unstructured.Unstructured) error {
 	if un == nil {
 		return fmt.Errorf("invalid argument: unstructured is nil")

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -136,7 +136,8 @@ func NewIgnoreNormalizer(overrides map[string]ResourceOverride) (diff.Normalizer
 	return &ignoreNormalizer{patches: patches}, nil
 }
 
-// Normalize removes fields from supplied resource using json paths from matching items of specified includedResources ignored differences list
+// Normalize removes fields from supplied resource using json paths from matching
+// items of specified resources ignored differences list
 func (n *ignoreNormalizer) Normalize(un *unstructured.Unstructured) error {
 	if un == nil {
 		return fmt.Errorf("invalid argument: unstructured is nil")

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -112,7 +112,7 @@ func (s *Syncer) StopWatching(key string) {
 }
 
 // Start function starts the synchronizer worker group.
-// Each worker keeps picking up tasks (which contains GitSync keys) to sync the includedResources.
+// Each worker keeps picking up tasks (which contains GitSync keys) to sync the resources.
 func (s *Syncer) Start(ctx context.Context) error {
 	numaLogger := logger.FromContext(ctx).WithName("synchronizer")
 	numaLogger.Info("Starting synchronizer...")
@@ -270,7 +270,7 @@ func (r *resourceInfoProviderStub) IsNamespaced(_ schema.GroupKind) (bool, error
 	return false, nil
 }
 
-// sync compares the live state of the watched includedResources to target state defined in git
+// sync compares the live state of the watched resources to target state defined in git
 // for the given GitSync. If it doesn't match, syncing the state to the live objects. Otherwise,
 // skip the syncing.
 func (s *Syncer) sync(

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -2,6 +2,11 @@ clusterName: "staging-usw2-k8s"
 syncTimeIntervalMs: 60000
 cascadeDeletion: false
 autoHealTimeIntervalMs: 30000
+includedResources: "group=apps,kind=Deployment;\
+group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
+group=numaflow.numaproj.io,kind=;\
+group=numaflow.numaproj.io,kind=;\
+group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 repoCredentials:
   - url: "github.com/numaproj-labs"
     httpCredential:

--- a/tests/manifests/config.yaml
+++ b/tests/manifests/config.yaml
@@ -2,6 +2,11 @@ clusterName: "staging-usw2-k8s"
 syncTimeIntervalMs: 60000
 autoHealTimeIntervalMs: 30000
 cascadeDeletion: false
+includedResources: "group=apps,kind=Deployment;\
+group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
+group=numaflow.numaproj.io,kind=;\
+group=numaflow.numaproj.io,kind=;\
+group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 repoCredentials:
 - url: "github.com/numaproj-labs"
   httpCredential:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #183 

### Modifications

This PR changes the cache to only watch Numaflow resources to minimize the scope of the cache. The included resources are configurable via ConfigMap.


### Verification

Verified in a local cluster with the following,
```
make start
kubectl apply -k config/samples/
```

