### PR TITLE
Update Controller ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,9 +4,28 @@ kind: ClusterRole
 metadata:
   name: numaplane-role
 rules:
-- apiGroups:
-  - '*'
+- apiGroups: ["numaflow.numaproj.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["numaplane.numaproj.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: [""]
   resources:
-  - '*'
+    - configmaps
+    - secrets
+    - serviceaccounts
+    - namespaces
   verbs:
-  - '*'
+    - '*'
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+    - rolebindings
+    - roles
+  verbs:
+    - '*'
+- apiGroups: ["apps"]
+  resources:
+    - deployments
+  verbs:
+    - '*'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #184 

### Modifications
This PR updates the Controller ClusterRole to no longer requires super user permission, instead only requires whats needed for manage Numaflow resources. 


### Verification

Verified in a local cluster to deploy a Numaflow pipeline.

