### PR TITLE
Logger fix

### DIFF
--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -288,7 +288,7 @@ func (s *Syncer) sync(
 	}
 
 	opts := []gitopsSync.SyncOpt{
-		gitopsSync.WithLogr(*numaLogger.WithValues("gitsync", gitSync).LogrLogger),
+		gitopsSync.WithLogr(*numaLogger.WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name)).LogrLogger),
 		gitopsSync.WithOperationSettings(false, true, false, false),
 		gitopsSync.WithManifestValidation(true),
 		gitopsSync.WithPruneLast(true),
@@ -346,7 +346,7 @@ func (s *Syncer) compareState(gitSync *v1alpha1.GitSync, targetObjs []*unstructu
 	}
 
 	diffOpts := []diff.Option{
-		diff.WithLogr(*logger.New().WithValues("gitsync", gitSync).LogrLogger),
+		diff.WithLogr(*logger.New().WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name)).LogrLogger),
 	}
 
 	modified, err := StateDiffs(reconciliationResult.Target, reconciliationResult.Live, overrides, diffOpts)

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -47,9 +47,9 @@ const (
 
 // The following map define the logr verbosity or NumaLogger semantic levels (constants above) mapping
 // to the zerolog levels (https://github.com/rs/zerolog/blob/master/log.go#L129).
-// This conversion/mapping is due to the following relationship between zerolog levels and logr verbosity:
-// - zerolog(4=Fatal) = "always want to see" => zerolog(-1=Trace) = "only want to see rarely, ex: for debug purposes"
-// - logrVerbosity(0) = "always want to see" => logrVerbosity(10) = "only want to see rarely, ex: for debug purposes"
+// This conversion/mapping is due to the following inverse relationship between zerolog levels and logr verbosity:
+// - zerolog(4=Fatal) = "always want to see" => zerolog(-2=Verbose) = "only want to see rarely, ex: for debug purposes"
+// - logrVerbosity(1) = "always want to see" => logrVerbosity(5) = "only want to see rarely, ex: for debug purposes"
 var logrVerbosityToZerologLevelMap = map[int]zerolog.Level{
 	FatalLevel:   4,
 	WarnLevel:    2,

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -279,7 +279,7 @@ func (ls *LogSink) log(zlEvent *zerolog.Event, msg string, keysAndValues []any) 
 	}
 
 	zlEvent.Fields(keysAndValues).
-		CallerSkipFrame(ls.depth + 1).
+		CallerSkipFrame(ls.depth).
 		Msg(msg)
 }
 

--- a/internal/util/logger/logger_test.go
+++ b/internal/util/logger/logger_test.go
@@ -382,3 +382,51 @@ func TestLevelChanges(t *testing.T) {
 		t.Errorf("\nActual:\n%+v\nExpected:\n%+v", actual, expected)
 	}
 }
+
+func TestLogrDirectly(t *testing.T) {
+	t.Run("infoOnly", func(t *testing.T) {
+		lvl := InfoLevel
+		nl, buf := mock(&lvl)
+
+		expected := LogJSON{
+			"info",
+			"info msg 1",
+			"",
+			loggerDefaultName,
+			"",
+			"",
+		}
+
+		nl.LogrLogger.Info("info msg 1")
+
+		var actual LogJSON
+		_ = json.Unmarshal(buf.Bytes(), &actual)
+
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("\nActual:\n%+v\nExpected:\n%+v", actual, expected)
+		}
+	})
+
+	t.Run("withVerbosity", func(t *testing.T) {
+		lvl := VerboseLevel
+		nl, buf := mock(&lvl)
+
+		expected := LogJSON{
+			"verbose",
+			"verbose msg 1",
+			"",
+			loggerDefaultName,
+			"",
+			"",
+		}
+
+		nl.LogrLogger.V(2).Info("verbose msg 1")
+
+		var actual LogJSON
+		_ = json.Unmarshal(buf.Bytes(), &actual)
+
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("\nActual:\n%+v\nExpected:\n%+v", actual, expected)
+		}
+	})
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj-labs/numaplane/issues/182

### Modifications

The log level mapping did not work as understood when packages call logr.Logger.Info func directly without calling the NumaLogger.Info or other function. A distinction had to be made between the 2 types of calls. For this reason, the wrapper functions (Info, Debug, etc.) call the sink Info function directly instead of setting the verbosity and then calling the Logger Info func. In addition, levels map was changed to solve additional problems with configmap not having set a log level resulting in a conflicting "zero" level. Other minor adjustments were made to avoid logging the entire gitsync manifest.


### Verification

Additional unit tests were added. Additional manual comparisons between "old logs" (prior to commit https://github.com/numaproj-labs/numaplane/commit/0d0a43dadae9e3dd830c20b62bc149119a9fd6e6) and "new logs" (with current PR changes) were performed.
