### PR TITLE
chore: dynamically pick up config change for cache setting

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 
-	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -139,7 +138,7 @@ func main() {
 
 	numaLogger.Info("Starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		numaLogger.Fatal(err, "Unable to start manager", zap.Error(err))
+		numaLogger.Fatal(err, "Unable to start manager")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.19.0
 	golang.org/x/sync v0.6.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -148,6 +147,7 @@ require (
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/net v0.21.0 // indirect

--- a/internal/sync/cache.go
+++ b/internal/sync/cache.go
@@ -107,8 +107,10 @@ type liveStateCache struct {
 func newLiveStateCache(
 	cluster clustercache.ClusterCache,
 ) LiveStateCache {
+	numaLogger := logger.New().WithName("live state cache")
 	return &liveStateCache{
 		cluster: cluster,
+		logger:  &numaLogger,
 	}
 }
 
@@ -386,9 +388,13 @@ func (c *liveStateCache) loadCacheSettings() (*cacheSettings, error) {
 // included resource to be watched during caching. The rules are
 // delimited by ';', and each rule is composed by both 'group'
 // and 'kind' which can be empty. For example,
-// 'group=apps,kind=Deployment;group=,kind=ConfigMap'.
+// 'group=apps,kind=Deployment;group=,kind=ConfigMap'. Note that
+// empty rule is valid.
 func parseResourceFilter(rules string) (*[]ResourceType, error) {
 	filteredResources := make([]ResourceType, 0)
+	if rules == "" {
+		return &filteredResources, nil
+	}
 	rulesArr := strings.Split(rules, ";")
 	err := fmt.Errorf("malformed resource filter rules %q", rules)
 	for _, rule := range rulesArr {

--- a/internal/sync/cache_test.go
+++ b/internal/sync/cache_test.go
@@ -208,6 +208,12 @@ func TestParseResourceFilter(t *testing.T) {
 		hasErr            bool
 	}{
 		{
+			name:              "valid empty rule",
+			rules:             "",
+			expectedResources: []ResourceType{},
+			hasErr:            false,
+		},
+		{
 			name:  "valid rules",
 			rules: "group=apps,kind=Deployment;group=rbac.authorization.k8s.io,kind=RoleBinding",
 			expectedResources: []ResourceType{

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -121,7 +121,7 @@ func (s *Syncer) Start(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(logger.WithLogger(ctx, numaLogger))
 	defer cancel()
 
-	err := s.stateCache.Init()
+	err := s.stateCache.Init(&numaLogger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #191 

### Modifications

This PR updates it to dynamically pick up config change for cache setting.


### Verification

Verified in a local cluster by update the `includedResources` field in config map and see the cache setting is reloaded.

