### PR TITLE
Fixed e2e tests configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,9 +209,21 @@ gitserver:
 		-t $(GITSERVER_IMAGE) \
 		--push .
 
+.PHONY: e2e-test-clean
+e2e-test-clean:
+	$(KUBECTL) delete -k tests/e2e/manifests --ignore-not-found=true
+	$(KUBECTL) delete -f tests/e2e/manifests/numaplane-ns.yaml --ignore-not-found=true
+
+.PHONY: e2e-test-start
+e2e-test-start: e2e-test-clean image
+	$(KUBECTL) apply -f tests/e2e/manifests/numaplane-ns.yaml
+	$(KUBECTL) kustomize tests/e2e/manifests | sed 's/CLUSTER_NAME_VALUE/$(CLUSTER_NAME)/g' | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
+
 test-e2e:
-test-%:
+test-%: e2e-test-start
 	kubectl delete -n numaplane-system -k ./tests/e2e-gitserver --ignore-not-found=true
 	kubectl apply -n numaplane-system -k ./tests/e2e-gitserver
 	go generate $(shell find ./tests/$* -name '*.go')
 	go test -v -timeout 15m -count 1 --tags test -p 1 ./tests/$*
+	$(MAKE) e2e-test-clean
+

--- a/tests/e2e-gitserver/gitserver.yaml
+++ b/tests/e2e-gitserver/gitserver.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: localgitserver
+  namespace: numaplane-system
 spec:
   serviceName: "localgitserver"
   replicas: 1
@@ -41,6 +42,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: localgitserver-service
+  namespace: numaplane-system
 spec:
   type: ClusterIP
   selector:

--- a/tests/e2e-gitserver/kustomization.yaml
+++ b/tests/e2e-gitserver/kustomization.yaml
@@ -6,8 +6,10 @@ commonLabels:
 
 configMapGenerator:
   - name: git-ssh-config
+    namespace: numaplane-system
     files:
       - authorized_keys=authorized_keys
   - name: git-http-config
+    namespace: numaplane-system
     files:
       - htpasswd=.htpasswd

--- a/tests/e2e/manifests/config.yaml
+++ b/tests/e2e/manifests/config.yaml
@@ -1,0 +1,31 @@
+clusterName: "staging-usw2-k8s"
+syncTimeIntervalMs: 60000
+autoHealTimeIntervalMs: 30000
+cascadeDeletion: false
+includedResources: "group=apps,kind=Deployment;\
+group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
+group=numaflow.numaproj.io,kind=;\
+group=numaflow.numaproj.io,kind=;\
+group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
+repoCredentials:
+- url: "localgitserver-service.numaplane-system.svc.cluster.local/git"
+  httpCredential:
+    username: "exampleUser"
+    password:
+      name: "http-creds"
+      key: "password"
+- url: "localgitserver-0.numaplane-system.svc.cluster.local/git"
+  sshCredential:
+    SSHKey:
+      name: "ssh-creds"
+      key: "sshKey"
+  tls:
+    insecureSkipVerify: true
+- url: "localgitserver-0.numaplane-system.svc.cluster.local/git"
+  httpCredential:
+    username: "exampleuser3"
+    password:
+      name: "http-creds"
+      key: "password"
+  tls:
+    insecureSkipVerify: true

--- a/tests/e2e/manifests/kustomization.yaml
+++ b/tests/e2e/manifests/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../config/default
+  - secret.yaml
+
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: IfNotPresent
+    target:
+      kind: Deployment
+      name: numaplane-controller-manager
+
+configMapGenerator:
+  - name: numaplane-controller-config
+    namespace: numaplane-system
+    files:
+      - config.yaml
+    behavior: merge  # Optional, defaults to "create"

--- a/tests/e2e/manifests/numaplane-ns.yaml
+++ b/tests/e2e/manifests/numaplane-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: numaplane-system

--- a/tests/e2e/manifests/secret.yaml
+++ b/tests/e2e/manifests/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: http-creds
+  namespace: numaplane-system
+type: Opaque
+data:
+  password: cm9vdA== # base64 version of the password value root

--- a/tests/e2e/testdata/gitsync.yaml
+++ b/tests/e2e/testdata/gitsync.yaml
@@ -4,8 +4,8 @@ metadata:
   name: gitsync-example
   namespace: numaplane-system
 spec:
-  path: sample-pipeline
-  repoUrl: http://localhost:8080/git/repo1.git
+  path: "sample-pipeline"
+  repoUrl: http://localgitserver-service.numaplane-system.svc.cluster.local/git/repo1.git
   targetRevision: master
   raw: {}
   destination:

--- a/tests/fixtures/given.go
+++ b/tests/fixtures/given.go
@@ -43,7 +43,8 @@ var (
 		Username: "root",
 		Password: "root",
 	}
-	localPath = "./local"
+	localPath   = "./local"
+	localGitUrl = "http://localhost:8080/git/repo1.git" // Localgit url is different what gitSync url inside controller should be
 )
 
 type Given struct {
@@ -128,16 +129,6 @@ func (g *Given) InitializeGitRepo() *Given {
 		g.t.Fatal(err)
 	}
 
-	// Check out to a specific branch if necessary, assuming master/main here
-	// This step is important if your operations depend on being on a specific branch
-	err = wt.Checkout(&git.CheckoutOptions{
-		Branch: plumbing.NewBranchReferenceName("master"),
-		Force:  true,
-	})
-	if err != nil {
-		g.t.Fatal(err)
-	}
-
 	// Pull the latest changes to ensure the local copy is up-to-date
 	err = wt.Pull(&git.PullOptions{
 		RemoteName:    "origin",
@@ -192,7 +183,7 @@ func (g *Given) InitializeGitRepo() *Given {
 // clone repository unless it's already been cloned
 func (g *Given) cloneRepo(ctx context.Context) (*git.Repository, error) {
 
-	cloneOpts := git.CloneOptions{URL: g.gitSync.Spec.RepoUrl, Auth: auth}
+	cloneOpts := git.CloneOptions{URL: localGitUrl, Auth: auth}
 
 	repo, err := git.PlainCloneContext(ctx, localPath, false, &cloneOpts)
 	if err != nil && errors.Is(err, git.ErrRepositoryAlreadyExists) {

--- a/tests/fixtures/given.go
+++ b/tests/fixtures/given.go
@@ -38,13 +38,16 @@ import (
 	planepkg "github.com/numaproj-labs/numaplane/pkg/client/clientset/versioned/typed/numaplane/v1alpha1"
 )
 
+// localGitUrl is set for local development/testing,
+// the GitSync controller uses a different URL configured in GitSync yaml.
+const localGitUrl = "http://localhost:8080/git/repo1.git"
+
 var (
 	auth = &http.BasicAuth{
 		Username: "root",
 		Password: "root",
 	}
-	localPath   = "./local"
-	localGitUrl = "http://localhost:8080/git/repo1.git" // Localgit url is different what gitSync url inside controller should be
+	localPath = "./local"
 )
 
 type Given struct {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Yes it fixes a bug

Fixes  https://github.com/numaproj-labs/numaplane/issues/190

### Modifications




**Configuration Manifests**: Introduced separate configuration manifests folder for  numaplane controller  for running e2e tests

**Makefile Enhancements**:
`e2e-test-clean`: Cleans up resources after tests to ensure a clean environment for subsequent test runs.
`e2e-test-start`: Prepares the environment for e2e testing, including setting up the NumaPlane Controller.

**GitSync YAML Update**: Modified to use Fully Qualified Domain Names (FQDN) for git urls.
**Kubernetes Secrets**: Added Kubernetes secrets to the GitSync Controller's configuration, to be used by the internal gitsync to sync repositories


### Verification

These improvements were thoroughly tested in a local cluster using the `make test-e2e` command

