### PR TITLE
fix deployment label

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -430,7 +430,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: controller-manager
-    app.kubernetes.io/name: deployment
+    app.kubernetes.io/name: controller-manager
     app.kubernetes.io/part-of: numaplane
   name: numaplane-controller-manager
   namespace: numaplane-system

--- a/config/manager/controller-manager.yaml
+++ b/config/manager/controller-manager.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: numaplane-controller-manager
   labels:
-    app.kubernetes.io/name: deployment
+    app.kubernetes.io/name: controller-manager
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: numaplane
 spec:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

I believe common practice is to name the Deployment label the same as the Pod label? 

Chandan was modifying this in a patch within numa-manifest-generator, so seems we should just change it here instead of that.


### Verification

Ran `make start` and confirmed Controller is running and has the new label.

