### PR TITLE
fix image repo; add initContainers to Deployment spec as empty array

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION ?= latest
 BASE_VERSION := latest
 # Default cluster name where numaplane get deployed, update it as needed.
 CLUSTER_NAME ?= staging-usw2-k8s
-IMAGE_NAMESPACE ?= quay.io/numaproj
+IMAGE_NAMESPACE ?= quay.io/numaio
 IMAGE_FULL_PATH ?= $(IMAGE_NAMESPACE)/$(IMG):$(VERSION)
 
 ## Location to install dependencies to

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -483,6 +483,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/numaplane
           name: config-volume
+      initContainers: []
       serviceAccountName: numaplane-sa
       terminationGracePeriodSeconds: 10
       volumes:

--- a/config/manager/controller-manager.yaml
+++ b/config/manager/controller-manager.yaml
@@ -49,6 +49,7 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
+      initContainers: []
       containers:
       - command:
         - /manager


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

Two modifications:
1. fix repo that we are pushing to in quay.io
2. Set `initContainers` to empty array in the Deployment spec, which makes it so that I can add an array-based patch to it in `numa-manifest-generator`. (I want to add an array-based patch, so that if we ever actually add an InitContainer in the open source side, we will simply append rather than overwriting.) 


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

