### PR TITLE
test: add e2e test case for Helm manifests

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -239,6 +239,22 @@ func (s *FunctionalSuite) TestHelm() {
 	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"new-deploy"})
 	w.Expect().CheckCommitStatus()
 
+	w.PushToGitRepo("helm/modified", []string{"values.yaml"}, false).Wait(30 * time.Second)
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"new-deploy"})
+	w.Expect().CheckCommitStatus()
+
+	w.Expect().VerifyResourceState("apps/v1", "deployments", "new-deploy", "spec", "replicas", 5)
+
+	s.Given().GitSync("@testdata/helm-gitsync-params.yaml").
+		When().
+		UpdateGitSyncAndWait().
+		Wait(30 * time.Second)
+
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"new-deploy"})
+	w.Expect().CheckCommitStatus()
+
+	w.Expect().VerifyResourceState("apps/v1", "deployments", "new-deploy", "spec", "replicas", 3)
+
 }
 
 func TestFunctionalSuite(t *testing.T) {

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -226,7 +226,7 @@ func (s *FunctionalSuite) TestHelm() {
 		CreateGitSyncAndWait()
 	defer w.DeleteGitSyncAndWait()
 
-	// verify all resources defined in kustomization file are created
+	// verify all resources defined in helm file are created
 	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"gitsync-example-helm-test"})
 	w.Expect().CheckCommitStatus()
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -82,7 +82,7 @@ func (s *FunctionalSuite) TestNumaflowGitSync() {
 	w.Expect().VerifyResourceState("numaflow.numaproj.io/v1alpha1", "pipelines", "simple-pipeline", "spec", "edge", initialEdges)
 
 	// remove pipeline manifest from repo
-	w.PushToGitRepo("numaflow/modified", []string{"http-pipeline.yaml"}, true).Wait(30 * time.Second)
+	w.PushToGitRepo("numaflow/modified", []string{"http-pipeline.yaml"}, true).Wait(45 * time.Second)
 
 	// verify that the pipeline has been deleted by GitSync and synced to current commit
 	w.Expect().ResourcesDontExist("numaflow.numaproj.io/v1alpha1", "pipelines", []string{"http-pipeline"})
@@ -193,7 +193,7 @@ func (s *FunctionalSuite) TestChangeRepoUrl() {
 
 }
 
-// // GitSync testing with kustomize manifests
+// GitSync testing with kustomize manifests
 func (s *FunctionalSuite) TestKustomize() {
 
 	// create repo containing kustomize manifests
@@ -203,17 +203,40 @@ func (s *FunctionalSuite) TestKustomize() {
 	defer w.DeleteGitSyncAndWait()
 
 	// verify all resources defined in kustomization file are created
-	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"test-deploy"})
-	w.Expect().ResourcesExist("v1", "configmaps", []string{"test-config"})
-	w.Expect().ResourcesExist("v1", "secrets", []string{"test-secret"})
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"kustomize-deploy"})
+	w.Expect().ResourcesExist("v1", "configmaps", []string{"kustomize-config"})
+	w.Expect().ResourcesExist("v1", "secrets", []string{"kustomize-secret"})
 	w.Expect().CheckCommitStatus()
 
 	// remove deployment resource from kustomization file
 	w.PushToGitRepo("kustomize/modified", []string{"kustomization.yaml"}, false).Wait(30 * time.Second)
 	// verify that deployment should be deleted while other resources remain
-	w.Expect().ResourcesDontExist("apps/v1", "deployments", []string{"test-deploy"})
-	w.Expect().ResourcesExist("v1", "configmaps", []string{"test-config"})
-	w.Expect().ResourcesExist("v1", "secrets", []string{"test-secret"})
+	w.Expect().ResourcesDontExist("apps/v1", "deployments", []string{"kustomize-deploy"})
+	w.Expect().ResourcesExist("v1", "configmaps", []string{"kustomize-config"})
+	w.Expect().ResourcesExist("v1", "secrets", []string{"kustomize-secret"})
+	w.Expect().CheckCommitStatus()
+
+}
+
+// GitSync testing with basic helm manifests
+func (s *FunctionalSuite) TestHelm() {
+
+	w := s.Given().GitSync("@testdata/helm-gitsync.yaml").InitializeGitRepo("helm/initial-commit").
+		When().
+		CreateGitSyncAndWait()
+	defer w.DeleteGitSyncAndWait()
+
+	// verify all resources defined in kustomization file are created
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"gitsync-example-helm-test"})
+	w.Expect().CheckCommitStatus()
+
+	// remove deployment manifest from repo
+	w.PushToGitRepo("helm/initial-commit", []string{"templates/deployment.yaml"}, true).Wait(30 * time.Second)
+	w.Expect().ResourcesDontExist("apps/v1", "deployments", []string{"gitsync-example-helm-test"})
+	w.Expect().CheckCommitStatus()
+
+	w.PushToGitRepo("helm/modified", []string{"templates/new-deploy.yaml"}, false).Wait(30 * time.Second)
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"new-deploy"})
 	w.Expect().CheckCommitStatus()
 
 }

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -235,16 +235,19 @@ func (s *FunctionalSuite) TestHelm() {
 	w.Expect().ResourcesDontExist("apps/v1", "deployments", []string{"gitsync-example-helm-test"})
 	w.Expect().CheckCommitStatus()
 
+	// adding new template to repo
 	w.PushToGitRepo("helm/modified", []string{"templates/new-deploy.yaml"}, false).Wait(30 * time.Second)
 	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"new-deploy"})
 	w.Expect().CheckCommitStatus()
 
+	// modifying the values.yaml target for helm
 	w.PushToGitRepo("helm/modified", []string{"values.yaml"}, false).Wait(30 * time.Second)
 	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"new-deploy"})
 	w.Expect().CheckCommitStatus()
 
 	w.Expect().VerifyResourceState("apps/v1", "deployments", "new-deploy", "spec", "replicas", 5)
 
+	// changing the GitSync spec to override values.yaml with ReplicaCount = 3
 	s.Given().GitSync("@testdata/helm-gitsync-params.yaml").
 		When().
 		UpdateGitSyncAndWait().
@@ -253,6 +256,7 @@ func (s *FunctionalSuite) TestHelm() {
 	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"new-deploy"})
 	w.Expect().CheckCommitStatus()
 
+	// verify change has occurred
 	w.Expect().VerifyResourceState("apps/v1", "deployments", "new-deploy", "spec", "replicas", 3)
 
 }

--- a/tests/e2e/manifests/kustomization.yaml
+++ b/tests/e2e/manifests/kustomization.yaml
@@ -13,6 +13,20 @@ patches:
     target:
       kind: Deployment
       name: numaplane-controller-manager
+  - patch: |-
+      - op: add
+        path: /rules/2/resources/-
+        value: secrets
+    target:
+      kind: ClusterRole
+      name: numaplane-role
+  - patch: |-
+      - op: add
+        path: /rules/2/resources/-
+        value: namespaces
+    target:
+      kind: ClusterRole
+      name: numaplane-role
 
 configMapGenerator:
   - name: numaplane-controller-config

--- a/tests/e2e/testdata/helm-gitsync-params.yaml
+++ b/tests/e2e/testdata/helm-gitsync-params.yaml
@@ -10,6 +10,9 @@ spec:
   helm:
     valueFiles:
     - "values.yaml"
+    parameters:
+    - name: "replicaCount"
+      value: "3"
   destination:
     cluster: staging-usw2-k8s
     namespace: numaplane-e2e

--- a/tests/e2e/testdata/helm-gitsync.yaml
+++ b/tests/e2e/testdata/helm-gitsync.yaml
@@ -1,0 +1,13 @@
+apiVersion: numaplane.numaproj.io/v1alpha1
+kind: GitSync
+metadata:
+  name: gitsync-example
+  namespace: numaplane-system
+spec:
+  path: "sample-manifests"
+  repoUrl: http://localgitserver-service.numaplane-system.svc.cluster.local/git/repo4.git
+  targetRevision: master
+  helm: {}
+  destination:
+    cluster: staging-usw2-k8s
+    namespace: numaplane-e2e

--- a/tests/e2e/testdata/helm/initial-commit/.helmignore
+++ b/tests/e2e/testdata/helm/initial-commit/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tests/e2e/testdata/helm/initial-commit/Chart.yaml
+++ b/tests/e2e/testdata/helm/initial-commit/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: helm-test
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/tests/e2e/testdata/helm/initial-commit/templates/NOTES.txt
+++ b/tests/e2e/testdata/helm/initial-commit/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "helm-test.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "helm-test.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "helm-test.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "helm-test.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/tests/e2e/testdata/helm/initial-commit/templates/_helpers.tpl
+++ b/tests/e2e/testdata/helm/initial-commit/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helm-test.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helm-test.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helm-test.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "helm-test.labels" -}}
+helm.sh/chart: {{ include "helm-test.chart" . }}
+{{ include "helm-test.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helm-test.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helm-test.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helm-test.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "helm-test.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tests/e2e/testdata/helm/initial-commit/templates/deployment.yaml
+++ b/tests/e2e/testdata/helm/initial-commit/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helm-test.fullname" . }}
+  labels:
+    {{- include "helm-test.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "helm-test.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "helm-test.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "helm-test.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tests/e2e/testdata/helm/initial-commit/templates/hpa.yaml
+++ b/tests/e2e/testdata/helm/initial-commit/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "helm-test.fullname" . }}
+  labels:
+    {{- include "helm-test.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "helm-test.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/tests/e2e/testdata/helm/initial-commit/templates/ingress.yaml
+++ b/tests/e2e/testdata/helm/initial-commit/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "helm-test.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "helm-test.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/tests/e2e/testdata/helm/initial-commit/templates/serviceaccount.yaml
+++ b/tests/e2e/testdata/helm/initial-commit/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "helm-test.serviceAccountName" . }}
+  labels:
+    {{- include "helm-test.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/tests/e2e/testdata/helm/initial-commit/values.yaml
+++ b/tests/e2e/testdata/helm/initial-commit/values.yaml
@@ -1,0 +1,107 @@
+# Default values for helm-test.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/tests/e2e/testdata/helm/modified/templates/new-deploy.yaml
+++ b/tests/e2e/testdata/helm/modified/templates/new-deploy.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "new-deploy"
+  labels:
+    {{- include "helm-test.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "helm-test.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "helm-test.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "helm-test.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tests/e2e/testdata/helm/modified/values.yaml
+++ b/tests/e2e/testdata/helm/modified/values.yaml
@@ -1,0 +1,107 @@
+# Default values for helm-test.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 5
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/tests/e2e/testdata/kustomize/initial-commit/configmap.yaml
+++ b/tests/e2e/testdata/kustomize/initial-commit/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: test-config
+  name: kustomize-config
 data:
   clusterName: "staging-usw2-k8s"
 

--- a/tests/e2e/testdata/kustomize/initial-commit/deployment.yaml
+++ b/tests/e2e/testdata/kustomize/initial-commit/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: test-deploy
+  name: kustomize-deploy
   labels:
     app: nginx
 spec:

--- a/tests/e2e/testdata/kustomize/initial-commit/secret.yaml
+++ b/tests/e2e/testdata/kustomize/initial-commit/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-secret
+  name: kustomize-secret
 type: Opaque
 data:
   password: cm9vdA==


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #228 

Adds e2e test case using Helm manifests. The Helm resources used were generated using `helm create`.

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

Added Helm manifest to testdata directory.
Tested that Helm templated resources are created and deleted when being added to or removed from repository.

### Verification

Ran `make test-e2e` multiple times.

