### PR TITLE
chore: Log clean up

### DIFF
--- a/internal/controller/gitsync_controller.go
+++ b/internal/controller/gitsync_controller.go
@@ -126,7 +126,7 @@ func (r *GitSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 // reconcile does the real logic
 func (r *GitSyncReconciler) reconcile(ctx context.Context, gitSync *apiv1.GitSync) error {
-	numaLogger := logger.FromContext(ctx)
+	numaLogger := logger.FromContext(ctx).WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name))
 
 	if !gitSync.Spec.ContainsClusterDestination(r.clusterName) {
 		gitSync.Status.MarkNotApplicable("ClusterMismatch", "This cluster isn't a destination")
@@ -135,7 +135,7 @@ func (r *GitSyncReconciler) reconcile(ctx context.Context, gitSync *apiv1.GitSyn
 
 	gitSyncKey := sync.KeyOfGitSync(gitSync)
 	if !gitSync.DeletionTimestamp.IsZero() {
-		numaLogger.Info("Deleting", "GitSync", gitSync)
+		numaLogger.Info("Deleting GitSync")
 		if r.syncer != nil {
 			err := sync.ProcessGitSyncDeletion(ctx, gitSync, r.syncer)
 			if err != nil {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -285,7 +285,7 @@ func (s *Syncer) sync(
 	}
 
 	opts := []gitopsSync.SyncOpt{
-		gitopsSync.WithLogr(*numaLogger.WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name)).LogrLogger),
+		gitopsSync.WithLogr(*numaLogger.LogrLogger),
 		gitopsSync.WithOperationSettings(false, true, false, false),
 		gitopsSync.WithManifestValidation(true),
 		gitopsSync.WithPruneLast(false),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

Clean up the log to make it concise:

- Remove gitsync dumping during deletion
- remove duplicate gitsync key logging

```
{"level":"info","worker":5,"gitSyncKey":"numaplane-system/gitsync-example","gitsync":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:387","ts":"2024-04-22T22:52:38.786274777Z","msg":"Syncing"}
{"level":"info","worker":5,"gitSyncKey":"numaplane-system/gitsync-example","gitsync":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:409","ts":"2024-04-22T22:52:38.792280194Z","msg":"Tasks (dry-run)"}
{"level":"info","worker":5,"gitSyncKey":"numaplane-system/gitsync-example","gitsync":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:921","ts":"2024-04-22T22:52:38.792343485Z","msg":"Updating operation state. phase:  -> Running, message: '' -> 'one or more tasks are running'"}
{"level":"info","worker":5,"gitSyncKey":"numaplane-system/gitsync-example","gitsync":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:1294","ts":"2024-04-22T22:52:38.792400194Z","msg":"Adding resource result, status: 'Pruned', phase: 'Succeeded', message: 'pruned'"}
{"level":"info","worker":5,"gitSyncKey":"numaplane-system/gitsync-example","gitsync":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:921","ts":"2024-04-22T22:52:38.792421027Z","msg":"Updating operation state. phase: Running -> Succeeded, message: 'one or more tasks are running' -> 'successfully synced (all tasks run)'"}
{"level":"info","worker":5,"gitSyncKey":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/syncer.go:245","ts":"2024-04-22T22:52:38.792471819Z","msg":"GitSync object is successfully synced."}
{"level":"info","logger":"numaplane","GitSync":{"kind":"GitSync","apiVersion":"numaplane.numaproj.io/v1alpha1","metadata":{"name":"gitsync-example","namespace":"numaplane-system","uid":"5bc4b124-1a8f-40ba-91a1-bb531201026b","resourceVersion":"2697029","generation":2,"creationTimestamp":"2024-04-22T22:52:07Z","deletionTimestamp":"2024-04-22T22:52:43Z","deletionGracePeriodSeconds":0,"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"numaplane.numaproj.io/v1alpha1\",\"kind\":\"GitSync\",\"metadata\":{\"annotations\":{},\"name\":\"gitsync-example\",\"namespace\":\"numaplane-system\"},\"spec\":{\"destination\":{\"cluster\":\"staging-usw2-k8s\",\"namespace\":\"numaflow-pipeline\"},\"path\":\"sample-pipeline\",\"raw\":{},\"repoUrl\":\"https://github.com/xdevxy/numaflow-example-pipelines.git\",\"targetRevision\":\"main\"}}\n"},"finalizers":["numaplane-controller"],"managedFields":[{"manager":"kubectl-client-side-apply","operation":"Update","apiVersion":"numaplane.numaproj.io/v1alpha1","time":"2024-04-22T22:52:07Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:destination":{".":{},"f:cluster":{},"f:namespace":{}},"f:path":{},"f:raw":{},"f:repoUrl":{},"f:targetRevision":{}}}},{"manager":"manager","operation":"Update","apiVersion":"numaplane.numaproj.io/v1alpha1","time":"2024-04-22T22:52:07Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\"numaplane-controller\"":{}}}}},{"manager":"manager","operation":"Update","apiVersion":"numaplane.numaproj.io/v1alpha1","time":"2024-04-22T22:52:38Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:commitStatus":{".":{},"f:hash":{},"f:syncTime":{},"f:synced":{}},"f:conditions":{},"f:phase":{}}},"subresource":"status"}]},"spec":{"repoUrl":"https://github.com/xdevxy/numaflow-example-pipelines.git","path":"sample-pipeline","targetRevision":"main","raw":{},"destination":{"cluster":"staging-usw2-k8s","namespace":"numaflow-pipeline"}},"status":{"phase":"Pending","conditions":[{"type":"Configured","status":"Unknown","lastTransitionTime":"2024-04-22T22:52:43Z","reason":"Unknown","message":""}],"commitStatus":{"hash":"c2e51abce2f7bcca3e0bff29a481d194d513164b","synced":true,"syncTime":"2024-04-22T22:52:38Z"}}},"caller":"controller/gitsync_controller.go:138","ts":"2024-04-22T22:52:43.514242363Z","msg":"Deleting"}
```


```
{"level":"info","worker":20,"gitSyncKey":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:387","ts":"2024-04-22T23:00:21.353786289Z","msg":"Syncing"}
{"level":"info","worker":20,"gitSyncKey":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:409","ts":"2024-04-22T23:00:21.359018456Z","msg":"Tasks (dry-run)"}
{"level":"info","worker":20,"gitSyncKey":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:921","ts":"2024-04-22T23:00:21.359059581Z","msg":"Updating operation state. phase:  -> Running, message: '' -> 'one or more tasks are running'"}
{"level":"info","worker":20,"gitSyncKey":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:1294","ts":"2024-04-22T23:00:21.359086831Z","msg":"Adding resource result, status: 'Pruned', phase: 'Succeeded', message: 'pruned'"}
{"level":"info","worker":20,"gitSyncKey":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/sync_context.go:921","ts":"2024-04-22T23:00:21.359092123Z","msg":"Updating operation state. phase: Running -> Succeeded, message: 'one or more tasks are running' -> 'successfully synced (all tasks run)'"}
{"level":"info","worker":20,"gitSyncKey":"numaplane-system/gitsync-example","logger":"numaplane.synchronizer","caller":"sync/syncer.go:245","ts":"2024-04-22T23:00:21.359114831Z","msg":"GitSync object is successfully synced."}
{"level":"info","gitsync":"numaplane-system/gitsync-example","logger":"numaplane","caller":"controller/gitsync_controller.go:138","ts":"2024-04-22T23:00:42.934987799Z","msg":"Deleting GitSync"}
```

### Verification
Verified in a local cluster
