### PR TITLE
feat: Add numaplane metrics support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/numaproj-labs/numaplane/internal/controller"
 	"github.com/numaproj-labs/numaplane/internal/controller/config"
+	"github.com/numaproj-labs/numaplane/internal/metrics"
 	"github.com/numaproj-labs/numaplane/internal/sync"
 	"github.com/numaproj-labs/numaplane/internal/util/kubernetes"
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
@@ -99,11 +100,15 @@ func main() {
 	numaLogger.SetLevel(config.LogLevel)
 
 	interval := config.SyncTimeIntervalMs
+	metricServer, err := metrics.NewMetricsServer()
+	if err != nil {
+		numaLogger.Fatal(err, "Failed to initialize metric")
+	}
 	kubectl := kubernetes.NewKubectl()
 	syncer := sync.NewSyncer(
 		mgr.GetClient(),
 		mgr.GetConfig(),
-		mgr.GetConfig(),
+		metricServer,
 		kubectl,
 		sync.WithTaskInterval(interval))
 	// Add syncer runner

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/ory/dockertest/v3 v3.10.0
+	github.com/prometheus/client_golang v1.18.0
 	github.com/rs/zerolog v1.29.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
@@ -121,7 +122,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -308,7 +308,7 @@ func Test_GetLatestManifests(t *testing.T) {
 					GitSource: v1alpha1.GitSource{
 						GitLocation: v1alpha1.GitLocation{
 							RepoUrl:        "https://github.com/numaproj-labs/numaplane.git",
-							TargetRevision: "controlledTestsPathEn",
+							TargetRevision: "main",
 							Path:           "tests/manifests/namespace-install",
 						},
 						Kustomize: &v1alpha1.KustomizeSource{},

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -27,6 +27,7 @@ import (
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/numaproj-labs/numaplane/internal/metrics"
 	gitshared "github.com/numaproj-labs/numaplane/internal/util/git"
 	"github.com/numaproj-labs/numaplane/pkg/apis/numaplane/v1alpha1"
 )
@@ -36,6 +37,7 @@ const (
 )
 
 var pool *dockertest.Pool
+var metric *metrics.MetricsServer
 
 // TestMain configures the testing environment by initializing a Docker container that serves as a local git server.
 // This function handles the connection to Docker, initiates the specified container if it's not currently active,
@@ -58,6 +60,8 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not connect to Docker; is it running? %s", err)
 	}
 	pool = p
+
+	metric, _ = metrics.NewMetricsServer()
 
 	relativePath := "../../tests/e2e-gitserver"
 	absolutePath, err := filepath.Abs(relativePath)
@@ -190,7 +194,7 @@ func Test_cloneRepo(t *testing.T) {
 				RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 				Force:    true,
 			}
-			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions)
+			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions, metric)
 			assert.NoError(t, cloneErr)
 			if tc.hasErr {
 				assert.NotNil(t, err)
@@ -352,14 +356,14 @@ func Test_GetLatestManifests(t *testing.T) {
 				RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 				Force:    true,
 			}
-			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions)
+			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions, metric)
 			assert.Nil(t, cloneErr)
 
 			// To break the continuous check of repo update, added the context timeout.
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
 
-			_, _, err = GetLatestManifests(ctx, r, nil, tc.gitSync)
+			_, _, err = GetLatestManifests(ctx, r, nil, tc.gitSync, metric)
 			if tc.hasErr {
 				assert.NotNil(t, err)
 			} else {
@@ -458,7 +462,7 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		Force:    true,
 	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -493,7 +497,7 @@ func TestGitCloneRepoSshLocalGitServerFileCredential(t *testing.T) {
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		Force:    true,
 	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -539,7 +543,7 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		Force:    true,
 	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -589,7 +593,7 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		Force:    true,
 	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,185 @@
+package metrics
+
+import (
+	"os"
+	"time"
+
+	gitopsSyncCommon "github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/numaproj-labs/numaplane/pkg/apis/numaplane/v1alpha1"
+)
+
+type MetricsServer struct {
+	syncCounter               *prometheus.CounterVec
+	gitSyncUpdateErrorCounter *prometheus.CounterVec
+	reconcileHistogram        *prometheus.HistogramVec
+	kubeRequestCounter        *prometheus.CounterVec
+	kubectlExecCounter        *prometheus.CounterVec
+	gitRequestCounter         *prometheus.CounterVec
+	gitRequestFailedCounter   *prometheus.CounterVec
+	gitRequestLatency         *prometheus.HistogramVec
+	monitoredKubeAPI          *prometheus.GaugeVec
+	kubeCachedResource        *prometheus.GaugeVec
+	kubeCacheFailed           *prometheus.CounterVec
+	hostname                  string
+}
+
+var (
+	descAppDefaultLabels = []string{"name", "namespace"}
+	syncCounter          = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "numaplane_gitsync_sync_total",
+			Help: "Number of GitSync syncs.",
+		},
+		append(descAppDefaultLabels, "dest_namespace", "dest_cluster", "phase"),
+	)
+
+	gitSyncUpdateErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "numaplane_gitsync_update_error",
+			Help: "Error on updating GitSync status.",
+		},
+		descAppDefaultLabels,
+	)
+
+	reconcileHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "numaplane_gitsync_reconcile_duration_second",
+			Help: "GitSync reconciliation performance.",
+		},
+		[]string{"namespace", "dest_cluster"},
+	)
+
+	kubeRequestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "numaplane_gitsync_kube_request_total",
+			Help: "Number of kubernetes requests executed during GitSync reconciliation.",
+		},
+		[]string{"response_code", "verb", "resource_kind", "resource_namespace"},
+	)
+
+	kubectlExecCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "numaplane_kubectl_exec_total",
+		Help: "Number of kubectl executions",
+	}, []string{"hostname", "command"})
+
+	gitRequestCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "numaplane_git_request_total",
+		Help: "Number of git request",
+	}, []string{})
+
+	gitRequestFailedCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "numaplane_git_request_failed_total",
+		Help: "Number of git request failed",
+	}, []string{})
+
+	gitRequestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "numaplane_git_request_latency",
+			Help: "Git request latency",
+		},
+		[]string{},
+	)
+
+	monitoredKubeAPI = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "numaplane_monitored_kube_api_total",
+		Help: "Number of monitored kubernetes API resources",
+	}, []string{})
+
+	kubeCachedResource = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "numaplane_kube_cache_resource_total",
+		Help: "Number of kubernetes resource objects in the cache",
+	}, []string{})
+
+	kubeCacheFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "numaplane_kube_cache_error",
+		Help: "Error on fetching cluster cache",
+	}, []string{})
+)
+
+func NewMetricsServer() (*MetricsServer, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(syncCounter)
+	metrics.Registry.MustRegister(gitSyncUpdateErrorCounter)
+	metrics.Registry.MustRegister(reconcileHistogram)
+	metrics.Registry.MustRegister(kubeRequestCounter)
+	metrics.Registry.MustRegister(kubectlExecCounter)
+	metrics.Registry.MustRegister(gitRequestCounter)
+	metrics.Registry.MustRegister(gitRequestFailedCounter)
+	metrics.Registry.MustRegister(gitRequestLatency)
+	metrics.Registry.MustRegister(monitoredKubeAPI)
+	metrics.Registry.MustRegister(kubeCachedResource)
+	metrics.Registry.MustRegister(kubeCacheFailed)
+
+	return &MetricsServer{
+		syncCounter:               syncCounter,
+		gitSyncUpdateErrorCounter: gitSyncUpdateErrorCounter,
+		reconcileHistogram:        reconcileHistogram,
+		kubeRequestCounter:        kubeRequestCounter,
+		kubectlExecCounter:        kubectlExecCounter,
+		gitRequestCounter:         gitRequestCounter,
+		gitRequestFailedCounter:   gitRequestFailedCounter,
+		gitRequestLatency:         gitRequestLatency,
+		monitoredKubeAPI:          monitoredKubeAPI,
+		kubeCachedResource:        kubeCachedResource,
+		kubeCacheFailed:           kubeCacheFailed,
+		hostname:                  hostname,
+	}, nil
+}
+
+// IncSync increments the sync counter for an application
+func (m *MetricsServer) IncSync(gitSync *v1alpha1.GitSync, state gitopsSyncCommon.OperationPhase) {
+	if !state.Completed() {
+		return
+	}
+	m.syncCounter.WithLabelValues(gitSync.Name, gitSync.Namespace, gitSync.Spec.Destination.Namespace, gitSync.Spec.Destination.Cluster, string(state)).Inc()
+}
+
+// InGitSyncUpdateError increments the sync counter for git sync status update failure
+func (m *MetricsServer) InGitSyncUpdateError(gitSync *v1alpha1.GitSync) {
+	m.gitSyncUpdateErrorCounter.WithLabelValues(gitSync.Name, gitSync.Namespace).Inc()
+}
+
+// ObserveReconcile increments the reconciled counter for an application
+func (m *MetricsServer) ObserveReconcile(gitSync *v1alpha1.GitSync, duration time.Duration) {
+	m.reconcileHistogram.WithLabelValues(gitSync.Namespace, gitSync.Spec.Destination.Cluster).Observe(duration.Seconds())
+}
+
+// IncKubernetesRequest increments the kubernetes requests counter for an application
+func (m *MetricsServer) IncKubernetesRequest(statusCode, verb, resourceKind, resourceNamespace string) {
+	m.kubeRequestCounter.WithLabelValues(statusCode, verb, resourceKind, resourceNamespace).Inc()
+}
+
+func (m *MetricsServer) IncKubectlExec(command string) {
+	m.kubectlExecCounter.WithLabelValues(m.hostname, command).Inc()
+}
+
+func (m *MetricsServer) IncGitRequest() {
+	m.gitRequestCounter.WithLabelValues().Inc()
+}
+
+func (m *MetricsServer) IncGitRequestFailed() {
+	m.gitRequestFailedCounter.WithLabelValues().Inc()
+}
+
+func (m *MetricsServer) ObserveGitRequestLatency(duration time.Duration) {
+	m.gitRequestLatency.WithLabelValues().Observe(duration.Seconds())
+}
+
+func (m *MetricsServer) SetMonitoredKubeAPI(apiRequest float64) {
+	m.monitoredKubeAPI.WithLabelValues().Set(apiRequest)
+}
+
+func (m *MetricsServer) SetKubeCachedResource(cache float64) {
+	m.kubeCachedResource.WithLabelValues().Set(cache)
+}
+
+func (m *MetricsServer) IncKubeCacheFailed() {
+	m.kubeCacheFailed.WithLabelValues().Inc()
+}

--- a/internal/metrics/transportwrapper.go
+++ b/internal/metrics/transportwrapper.go
@@ -1,0 +1,22 @@
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/argoproj/pkg/kubeclientmetrics"
+	"k8s.io/client-go/rest"
+)
+
+// AddMetricsTransportWrapper adds a transport wrapper which increments 'numaplane_app_k8s_request_total' counter on each kubernetes request
+func AddMetricsTransportWrapper(server *MetricsServer, config *rest.Config) *rest.Config {
+	inc := func(resourceInfo kubeclientmetrics.ResourceInfo) error {
+		namespace := resourceInfo.Namespace
+		kind := resourceInfo.Kind
+		statusCode := strconv.Itoa(resourceInfo.StatusCode)
+		server.IncKubernetesRequest(statusCode, string(resourceInfo.Verb), kind, namespace)
+		return nil
+	}
+
+	newConfig := kubeclientmetrics.AddMetricsTransportWrapper(config, inc)
+	return newConfig
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -153,7 +153,9 @@ func (s *Syncer) Start(ctx context.Context) error {
 		e := s.gitSyncList.Front()
 		if key, ok := e.Value.(string); ok {
 			s.gitSyncList.MoveToBack(e)
+			startTime := time.Now()
 			keyCh <- key
+			s.metricsServer.ObserveWorkerQueueSyncWaitTime(time.Since(startTime))
 		}
 	}
 

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/numaproj-labs/numaplane/internal/metrics"
 )
 
 type MockKubectl struct {
@@ -33,12 +35,17 @@ func (m *MockKubectl) DeleteResource(ctx context.Context, config *rest.Config, g
 
 func newFakeSyncer() *Syncer {
 	client := fake.NewClientBuilder().Build()
+	metric, err := metrics.NewMetricsServer()
+	if err != nil {
+		panic(err)
+	}
+
 	//stateCache := newFakeLivStateCache(t)
 	kubectl := &MockKubectl{Kubectl: &kubetest.MockKubectlCmd{}}
 	syncer := NewSyncer(
 		client,
 		&rest.Config{Host: "https://localhost:6443"},
-		&rest.Config{Host: "https://localhost:6443"},
+		metric,
 		kubectl,
 	)
 	return syncer


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #138 

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

Added below metrics:

**Syncing**
- [x] Number of resource synced
- [x] Gitsync reconciliation performance, How long the reconciliation takes.
- [x] Gitsync time on waiting on the queue, to indicate if work queue under backpressure
- [x] Error on updating GitSync status

**K8s API calls** (during syncing/cache)
- [x] Number of kubernetes requests executed during gitops reconciliation
- [x] Number of kubectl executions

**Cache**
- [x] Number of monitored kubernetes API resources
- [x] Number of k8s resource objects in the cache
- [x] Error on fetching cluster cache

**Git access**
- [x] Number of git request 
- [x] Number of failed git request
- [x] Git request latency

Saturation
- [x] Pending gitsync task on work queue

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

