### PR TITLE
Fixed flaky tests

### DIFF
--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -40,9 +40,9 @@ var pool *dockertest.Pool
 // This function handles the connection to Docker, initiates the specified container if it's not currently active,
 // and performs test case execution. Post-execution, it ensures thorough cleanup of all utilized resources.
 // Inside the Docker container, it sets up a test repository accessible via:
-// - SSH at ssh://root@localhost:2222/var/www/git/test.git
-// - HTTP at http://localhost:8080/git/test.git, served by the Apache HTTP server
-// - HTTPS at https://localhost:8443/git/test.git, secured with a self-signed certificate.
+// - SSH at ssh://root@localhost:2222/var/www/git/repo1.git
+// - HTTP at http://localhost:8080/git/repo1.git, served by the Apache HTTP server
+// - HTTPS at https://localhost:8443/git/repo1.git, secured with a self-signed certificate.
 // The default credentials for HTTP access are root:root.
 // The default credentials for SSH access are also root:root.
 // A default public SSH key (ssh-ed25519) is pre-added to the container's authorized keys.
@@ -428,7 +428,7 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 			Optional:        nil,
 		}},
 	}
-	repoUrL := "ssh://root@localhost:2222/var/www/git/test.git"
+	repoUrL := "ssh://root@localhost:2222/var/www/git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.NotNil(t, cloneOptions)
@@ -472,7 +472,7 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 			},
 		},
 	}
-	repoUrL := "http://localhost:8080/git/test.git"
+	repoUrL := "http://localhost:8080/git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)
@@ -516,7 +516,7 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 
 		},
 	}
-	repoUrL := "https://localhost:8443/git/test.git"
+	repoUrL := "https://localhost:8443/git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

No its just a bug fix .

### Modifications

Changed  unit tests repo from 

```
- SSH at ssh://root@localhost:2222/var/www/git/test.git
- HTTP at http://localhost:8080/git/test.git, served by the Apache HTTP server
 - HTTPS at https://localhost:8443/git/test.git, secured with a self-signed certificate.
```

to 

```
- SSH at ssh://root@localhost:2222/var/www/git/repo1.git
- HTTP at http://localhost:8080/git/repo1.git, served by the Apache HTTP server 
 - HTTPS at https://localhost:8443/git/repo1.git, secured with a self-signed certificate.

```
As in new local git server we are not using test.git repo but repo1.git
### Verification
Running `make test`

