### PR TITLE
chore: support for turning off auto heal

### DIFF
--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -223,6 +223,13 @@ func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 		numaLogger.Error(err, "error getting the global config")
 	}
 
+	autoHeal := true
+	interval := globalConfig.AutoHealTimeIntervalMs
+	// Check if auto heal is enabled
+	if interval == 0 {
+		autoHeal = false
+	}
+
 	numaLogger.SetLevel(globalConfig.LogLevel)
 
 	repo, err := git.CloneRepo(ctx, s.client, gitSync, globalConfig)
@@ -233,6 +240,22 @@ func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 	if err != nil {
 		return fmt.Errorf("failed to get the manifest of key %q, %w", key, err)
 	}
+
+	namespacedName := types.NamespacedName{
+		Namespace: gitSync.Namespace,
+		Name:      gitSync.Name,
+	}
+	lastSyncedCommitHash, err := getCommitStatus(ctx, s.client, namespacedName, &numaLogger)
+	if err != nil {
+		return fmt.Errorf("failed to get the current commit status of key %q, %w", key, err)
+	}
+	// If auto heal is not enabled and the target commit hash is the same as last sync,
+	// skip the syncing.
+	if !autoHeal && lastSyncedCommitHash != nil && lastSyncedCommitHash.Hash == commitHash {
+		numaLogger.Info("Skip the syncing as there is no changes and auto heal turned off.")
+		return nil
+	}
+
 	uns, err := applyAnnotationAndNamespace(manifests, gitSyncName, gitSync.Spec.Destination.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to parse the manifest of key %q, %w", key, err)
@@ -243,11 +266,6 @@ func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 	if syncState.Successful() {
 		synced = true
 		numaLogger.Info("GitSync object is successfully synced.")
-	}
-
-	namespacedName := types.NamespacedName{
-		Namespace: gitSync.Namespace,
-		Name:      gitSync.Name,
 	}
 
 	if !gitSync.GetDeletionTimestamp().IsZero() {
@@ -394,6 +412,25 @@ func applyAnnotationAndNamespace(manifests []*unstructured.Unstructured, gitSync
 		uns = append(uns, m)
 	}
 	return uns, nil
+}
+
+func getCommitStatus(
+	ctx context.Context,
+	kubeClient client.Client,
+	namespacedName types.NamespacedName,
+	numaLogger *logger.NumaLogger,
+) (*v1alpha1.CommitStatus, error) {
+	gitSync := &v1alpha1.GitSync{}
+	if err := kubeClient.Get(ctx, namespacedName, gitSync); err != nil {
+		// if we aren't able to do a Get, then either it's been deleted in the past, or something else went wrong
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		} else {
+			numaLogger.Error(err, "Unable to get GitSync", "err")
+			return nil, err
+		}
+	}
+	return gitSync.Status.CommitStatus, nil
 }
 
 // updateCommitStatus will update the commit status in git sync CR.

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -252,7 +252,7 @@ func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 	// If auto heal is not enabled and the target commit hash is the same as last sync,
 	// skip the syncing.
 	if !autoHeal && lastSyncedCommitHash != nil && lastSyncedCommitHash.Hash == commitHash {
-		numaLogger.Info("Skip the syncing as there is no changes and auto heal turned off.")
+		numaLogger.Info("Skip the syncing as there are no changes and auto heal is turned off.")
 		return nil
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #235 

### Modifications

This PR supports to turn off auto heal if it is configured so.


### Verification

Tested in a local cluster with `autoHealTimeIntervalMs` not set.  Auto heal is off so the syncing is skipped if no new changes.

