### PR TITLE
fix: git fetch should include credentials

### DIFF
--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -40,7 +40,7 @@ func CloneRepo(
 		return nil, fmt.Errorf("error getting  the  clone options: %v", err)
 	}
 
-	fetchOptions, err := gitShared.GetRepoFetchOptions(ctx, client, gitSync.Spec.RepoUrl, globalConfig)
+	fetchOptions, err := gitShared.GetRepoFetchOptions(ctx, gitCredentials, client, gitSync.Spec.RepoUrl)
 	if err != nil {
 		return nil, fmt.Errorf("error getting  the  clone options: %v", err)
 	}

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 
 	argoGit "github.com/argoproj/argo-cd/v2/util/git"
@@ -40,7 +39,12 @@ func CloneRepo(
 	if err != nil {
 		return nil, fmt.Errorf("error getting  the  clone options: %v", err)
 	}
-	return cloneRepo(ctx, gitSync, cloneOptions)
+
+	fetchOptions, err := gitShared.GetRepoFetchOptions(ctx, client, gitSync.Spec.RepoUrl, globalConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error getting  the  clone options: %v", err)
+	}
+	return cloneRepo(ctx, gitSync, cloneOptions, fetchOptions)
 }
 
 // GetLatestManifests gets the latest manifests from the Git repository.
@@ -247,6 +251,7 @@ func fetchUpdates(ctx context.Context,
 	if err != nil {
 		return err
 	}
+
 	pullOptions, err := gitShared.GetRepoPullOptions(ctx, credentials, client, gitSync.Spec.RepoUrl, branch)
 	if err != nil {
 		return err
@@ -264,10 +269,15 @@ func fetchUpdates(ctx context.Context,
 	return nil
 }
 
-func cloneRepo(ctx context.Context, gitSync *v1alpha1.GitSync, options *git.CloneOptions) (*git.Repository, error) {
+func cloneRepo(
+	ctx context.Context,
+	gitSync *v1alpha1.GitSync,
+	cloneOptions *git.CloneOptions,
+	fetchOptions *git.FetchOptions,
+) (*git.Repository, error) {
 	path := getLocalRepoPath(gitSync)
 
-	r, err := git.PlainCloneContext(ctx, path, false, options)
+	r, err := git.PlainCloneContext(ctx, path, false, cloneOptions)
 	if err != nil {
 		if errors.Is(err, git.ErrRepositoryAlreadyExists) {
 			// Open the existing repo and return it.
@@ -280,10 +290,10 @@ func cloneRepo(ctx context.Context, gitSync *v1alpha1.GitSync, options *git.Clon
 		return nil, err
 	}
 
-	// No need to fetch the references if  the target revision is already main or master (branches)
+	// No need to fetch the references if the target revision is already main or master (branches)
 	if gitSync.Spec.TargetRevision != "main" && gitSync.Spec.TargetRevision != "master" {
 		// fetch all references
-		err = fetchAll(r)
+		err = fetchAll(r, fetchOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -381,16 +391,16 @@ func checkoutRepo(repo *git.Repository, refName string) error {
 	return fmt.Errorf("reference '%s' not found as a branch, tag, or in any branch as a commit: %v", refName, err)
 }
 
-func fetchAll(repo *git.Repository) error {
+func fetchAll(
+	repo *git.Repository,
+	fetchOptions *git.FetchOptions,
+) error {
 	remote, err := repo.Remote("origin")
 	if err != nil {
 		return fmt.Errorf("failed to get remote: %v", err)
 	}
-	// Fetch using default options
-	err = remote.Fetch(&git.FetchOptions{
-		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-		Force:    true,
-	})
+
+	err = remote.Fetch(fetchOptions)
 	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return fmt.Errorf("failed to fetch repo: %v", err)
 	}

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/golang/mock/gomock"
@@ -181,7 +182,12 @@ func Test_cloneRepo(t *testing.T) {
 			cloneOptions := &git.CloneOptions{
 				URL: tc.gitSync.Spec.RepoUrl,
 			}
-			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions)
+
+			fetchOptions := &git.FetchOptions{
+				RefSpecs: []config.RefSpec{"refs/*:refs/*"},
+				Force:    true,
+			}
+			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions)
 			assert.NoError(t, cloneErr)
 			if tc.hasErr {
 				assert.NotNil(t, err)
@@ -339,7 +345,11 @@ func Test_GetLatestManifests(t *testing.T) {
 			cloneOptions := &git.CloneOptions{
 				URL: tc.gitSync.Spec.RepoUrl,
 			}
-			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions)
+			fetchOptions := &git.FetchOptions{
+				RefSpecs: []config.RefSpec{"refs/*:refs/*"},
+				Force:    true,
+			}
+			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions)
 			assert.Nil(t, cloneErr)
 
 			// To break the continuous check of repo update, added the context timeout.
@@ -442,7 +452,11 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 
 	gitSync := newGitSync("test", repoUrL, "gitClone", "master")
 
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions)
+	fetchOptions := &git.FetchOptions{
+		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
+		Force:    true,
+	}
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -483,7 +497,11 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)
 	gitSync := newGitSync("test", repoUrL, "gitCloned", "master")
 
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions)
+	fetchOptions := &git.FetchOptions{
+		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
+		Force:    true,
+	}
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -528,7 +546,11 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 	gitSync := newGitSync("test", repoUrL, "gitCloned", "master")
 	log.Println(cloneOptions)
 
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions)
+	fetchOptions := &git.FetchOptions{
+		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
+		Force:    true,
+	}
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -126,13 +126,12 @@ func GetRepoPullOptions(ctx context.Context, repoCred *apiv1.RepoCredential, kub
 // repo with HTTP, SSH, or TLS credentials from Kubernetes secrets.
 func GetRepoFetchOptions(
 	ctx context.Context,
+	repoCred *apiv1.RepoCredential,
 	kubeClient k8sClient.Client,
 	repoUrl string,
-	globalConfig controllerConfig.GlobalConfig,
 ) (*git.FetchOptions, error) {
 
-	gitCredentials := FindCredByUrl(repoUrl, globalConfig)
-	method, skipTls, err := GetAuthMethod(ctx, gitCredentials, kubeClient, repoUrl)
+	method, skipTls, err := GetAuthMethod(ctx, repoCred, kubeClient, repoUrl)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #244

### Modifications
This PR updates git Fetch options take auth as well.


### Verification
Tried with gisync in local cluster
```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: GitSync
metadata:
  name: oss-analytics-shakira-test-control-repo1-qal-usw2-eks
  namespace: oss-analytics-shakiratestcontrolrepo1-usw2-qal
spec:
  path: ""
  repoUrl: https://github.intuit.com/oss-analytics/shakira-test-control-repo1-deployment.git
  targetRevision: environments/qal-usw2-eks
  raw: {}
  destination:
    cluster: ip-msaas-ppd-usw2-k8s
    namespace: oss-analytics-shakiratestcontrolrepo1-usw2-qal
```
