### PR TITLE
Persistent storage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       gitserver:
-        image: quay.io/numaio/localgitserver
+        image: quay.io/numaio/localgitserver:latest
         ports:
           - 2222:22
           - 8443:443

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       gitserver:
-        image: quay.io/numaio/localgitserver
+        image: quay.io/numaio/numaplane-e2e-gitserver
         ports:
           - 2222:22
           - 8443:443

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       gitserver:
-        image: quay.io/numaio/numaplane-e2e-gitserver
+        image: quay.io/numaio/localgitserver
         ports:
           - 2222:22
           - 8443:443

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Dockerfile.cross
 
 # tmp directory built for e2e test
 tests/e2e/local
+tests/e2e-gitserver/Dockerfile
+tests/e2e-gitserver/gitscript.sh
+tests/e2e-gitserver/start.sh

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -437,6 +437,34 @@ metadata:
   name: numaplane-controller-config
   namespace: numaplane-system
 ---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    type: local
+  name: repo-pv
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /tmp
+  storageClassName: manual
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: repo-pvc
+  namespace: numaplane-system
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: manual
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -495,6 +523,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/numaplane
           name: config-volume
+        - mountPath: /tmp
+          name: repo-volume
       initContainers: []
       serviceAccountName: numaplane-sa
       terminationGracePeriodSeconds: 10
@@ -502,3 +532,6 @@ spec:
       - configMap:
           name: numaplane-controller-config
         name: config-volume
+      - name: repo-volume
+        persistentVolumeClaim:
+          claimName: repo-pvc

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -442,7 +442,7 @@ kind: PersistentVolume
 metadata:
   labels:
     type: local
-  name: repo-pv
+  name: numaplane-repo-pv
 spec:
   accessModes:
   - ReadWriteOnce
@@ -450,12 +450,12 @@ spec:
     storage: 5Gi
   hostPath:
     path: /tmp
-  storageClassName: manual
+  storageClassName: standard
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: repo-pvc
+  name: numaplane-repo-pvc
   namespace: numaplane-system
 spec:
   accessModes:
@@ -463,7 +463,7 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: manual
+  storageClassName: standard
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -534,4 +534,4 @@ spec:
         name: config-volume
       - name: repo-volume
         persistentVolumeClaim:
-          claimName: repo-pvc
+          claimName: numaplane-repo-pvc

--- a/config/manager/controller-manager.yaml
+++ b/config/manager/controller-manager.yaml
@@ -83,9 +83,14 @@ spec:
         volumeMounts: 
           - name: config-volume
             mountPath: /etc/numaplane
+          - name: repo-volume
+            mountPath: /etc/gitrepo
       serviceAccountName: numaplane-sa
       terminationGracePeriodSeconds: 10
       volumes:
         - name: config-volume
           configMap:
             name: numaplane-controller-config
+        - name: repo-volume
+          persistentVolumeClaim:
+            claimName: repo-pvc

--- a/config/manager/controller-manager.yaml
+++ b/config/manager/controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
           - name: config-volume
             mountPath: /etc/numaplane
           - name: repo-volume
-            mountPath: /etc/gitrepo
+            mountPath: /tmp
       serviceAccountName: numaplane-sa
       terminationGracePeriodSeconds: 10
       volumes:

--- a/config/manager/controller-manager.yaml
+++ b/config/manager/controller-manager.yaml
@@ -93,4 +93,4 @@ spec:
             name: numaplane-controller-config
         - name: repo-volume
           persistentVolumeClaim:
-            claimName: repo-pvc
+            claimName: numaplane-repo-pvc

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
 - controller-manager.yaml
 - controller-config.yaml
+- persistent-volume.yaml
+- persistent-volume-claim.yaml
 
 images:
 - name: quay.io/numaproj/numaplane-controller

--- a/config/manager/persistent-volume-claim.yaml
+++ b/config/manager/persistent-volume-claim.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: repo-pvc
+  name: numaplane-repo-pvc
 spec:
-  storageClassName: manual
+  storageClassName: standard
   accessModes:
     - ReadWriteOnce
   resources:

--- a/config/manager/persistent-volume-claim.yaml
+++ b/config/manager/persistent-volume-claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: repo-pvc
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/config/manager/persistent-volume.yaml
+++ b/config/manager/persistent-volume.yaml
@@ -11,4 +11,4 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/etc/gitrepo"
+      path: "/tmp"

--- a/config/manager/persistent-volume.yaml
+++ b/config/manager/persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: repo-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/etc/gitrepo"

--- a/config/manager/persistent-volume.yaml
+++ b/config/manager/persistent-volume.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: repo-pv
+  name: numaplane-repo-pv
   labels:
     type: local
 spec:
-  storageClassName: manual
+  storageClassName: standard
   capacity:
     storage: 5Gi
   accessModes:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
@@ -4,8 +4,8 @@ metadata:
   name: gitsync-example
   namespace: numaplane-system
 spec:
-  path: "sample-pipeline"
-  repoUrl: https://github.com/xdevxy/numaflow-example-pipelines.git
+  path: ""
+  repoUrl: https://github.com/shubhamdixit863/yamlrepo
   targetRevision: main
   raw: {}
   destination:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_gitsync.yaml
@@ -4,8 +4,8 @@ metadata:
   name: gitsync-example
   namespace: numaplane-system
 spec:
-  path: ""
-  repoUrl: https://github.com/shubhamdixit863/yamlrepo
+  path: "sample-pipeline"
+  repoUrl: https://github.com/xdevxy/numaflow-example-pipelines.git
   targetRevision: main
   raw: {}
   destination:

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -40,8 +40,9 @@ type GlobalConfig struct {
 	AutoHealEnabled    bool   `json:"autoHealEnabled" mapstructure:"autoHealEnabled"`
 	IncludedResources  string `json:"includedResources" mapstructure:"includedResources"`
 	// RepoCredentials maps each Git Repository Path prefix to the corresponding credentials that are needed for it
-	RepoCredentials []apiv1.RepoCredential `json:"repoCredentials" mapstructure:"repoCredentials"`
-	LogLevel        int                    `json:"logLevel" mapstructure:"logLevel"`
+	RepoCredentials         []apiv1.RepoCredential `json:"repoCredentials" mapstructure:"repoCredentials"`
+	LogLevel                int                    `json:"logLevel" mapstructure:"logLevel"`
+	PersistentRepoClonePath string                 `json:"persistentRepoClonePath" mapstructure:"persistentRepoClonePath"`
 }
 
 func (cm *ConfigManager) GetConfig() (GlobalConfig, error) {

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -30,6 +30,7 @@ func TestLoadConfigMatchValues(t *testing.T) {
 	assert.Nil(t, err, "Failed to load configuration")
 
 	assert.Equal(t, "staging-usw2-k8s", config.ClusterName, "ClusterName does not match")
+	assert.Equal(t, "/tmp", config.PersistentRepoClonePath, "PersistentRepoClonePath does not match")
 	assert.Equal(t, 30000, config.SyncTimeIntervalMs, "SyncTimeIntervalMs does not match")
 	assert.Equal(t, true, config.AutoHealEnabled, "AutoHealEnabled does not match")
 	assert.Equal(t, false, config.CascadeDeletion, "CascadeDeletion Field does not match")

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -214,13 +214,11 @@ func isRootDir(path string) bool {
 // by default it will use /tmp as base directory
 // unless LOCAL_REPO_PATH env is set.
 func getLocalRepoPath(gitSync *v1alpha1.GitSync) string {
-	baseDir := os.Getenv("LOCAL_REPO_PATH")
+	// baseDir is persistent volume path on the cluster node
+	// TODO // should we get it from config variable ?
+	baseDir := "/etc/gitrepo"
 	repoUrl := strconv.FormatUint(xxhash.Sum64([]byte(gitSync.Spec.RepoUrl)), 16)
-	if baseDir != "" {
-		return fmt.Sprintf("%s/%s/%s", baseDir, gitSync.Name, repoUrl)
-	} else {
-		return fmt.Sprintf("/tmp/%s/%s", gitSync.Name, repoUrl)
-	}
+	return fmt.Sprintf("%s/%s/%s", baseDir, gitSync.Name, repoUrl)
 }
 
 func GetCurrentBranch(r *git.Repository) (string, error) {

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -216,7 +216,7 @@ func isRootDir(path string) bool {
 func getLocalRepoPath(gitSync *v1alpha1.GitSync) string {
 	// baseDir is persistent volume path on the cluster node
 	// TODO // should we get it from config variable ?
-	baseDir := "/etc/gitrepo"
+	baseDir := "/tmp"
 	repoUrl := strconv.FormatUint(xxhash.Sum64([]byte(gitSync.Spec.RepoUrl)), 16)
 	return fmt.Sprintf("%s/%s/%s", baseDir, gitSync.Name, repoUrl)
 }

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -443,7 +443,7 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 			Key:             "sshKey",
 		}}},
 	}
-	repoUrL := "ssh://root@localhost:2222/var/www/public-git/repo1.git"
+	repoUrL := "ssh://root@localhost:2222/var/www/git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.NotNil(t, cloneOptions)
@@ -474,7 +474,7 @@ func TestGitCloneRepoSshLocalGitServerFileCredential(t *testing.T) {
 			Key:          "sshKey",
 		}}},
 	}
-	repoUrL := "ssh://root@localhost:2222/var/www/public-git/repo1.git"
+	repoUrL := "ssh://root@localhost:2222/var/www/git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.NotNil(t, cloneOptions)
@@ -519,7 +519,7 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 			},
 		},
 	}
-	repoUrL := "http://localhost:8080/public-git/repo1.git"
+	repoUrL := "http://localhost:8080/git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)
@@ -564,7 +564,7 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 
 		},
 	}
-	repoUrL := "https://localhost:8443/public-git/repo1.git"
+	repoUrL := "https://localhost:8443/git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -443,7 +443,7 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 			Key:             "sshKey",
 		}}},
 	}
-	repoUrL := "ssh://root@localhost:2222/var/www/git/repo1.git"
+	repoUrL := "ssh://root@localhost:2222/var/www/public-git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.NotNil(t, cloneOptions)
@@ -474,7 +474,7 @@ func TestGitCloneRepoSshLocalGitServerFileCredential(t *testing.T) {
 			Key:          "sshKey",
 		}}},
 	}
-	repoUrL := "ssh://root@localhost:2222/var/www/git/repo1.git"
+	repoUrL := "ssh://root@localhost:2222/var/www/public-git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.NotNil(t, cloneOptions)
@@ -519,7 +519,7 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 			},
 		},
 	}
-	repoUrL := "http://localhost:8080/git/repo1.git"
+	repoUrL := "http://localhost:8080/public-git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)
@@ -564,7 +564,7 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 
 		},
 	}
-	repoUrL := "https://localhost:8443/git/repo1.git"
+	repoUrL := "https://localhost:8443/public-git/repo1.git"
 	cloneOptions, err := gitshared.GetRepoCloneOptions(context.Background(), credential, client, repoUrL)
 	assert.NoError(t, err)
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -183,7 +183,7 @@ func Test_cloneRepo(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync)
+			localRepoPath := getLocalRepoPath(tc.gitSync, context.Background())
 			err := os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{
@@ -346,7 +346,7 @@ func Test_GetLatestManifests(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync)
+			localRepoPath := getLocalRepoPath(tc.gitSync, context.Background())
 			err := os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -183,8 +183,9 @@ func Test_cloneRepo(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync, context.Background())
-			err := os.RemoveAll(localRepoPath)
+			localRepoPath, err := getLocalRepoPath(tc.gitSync)
+			assert.Nil(t, err)
+			err = os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{
 				URL: tc.gitSync.Spec.RepoUrl,
@@ -346,8 +347,9 @@ func Test_GetLatestManifests(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync, context.Background())
-			err := os.RemoveAll(localRepoPath)
+			localRepoPath, err := getLocalRepoPath(tc.gitSync)
+			assert.Nil(t, err)
+			err = os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{
 				URL: tc.gitSync.Spec.RepoUrl,
@@ -465,7 +467,7 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitClone")
 	assert.NoError(t, err)
@@ -500,7 +502,7 @@ func TestGitCloneRepoSshLocalGitServerFileCredential(t *testing.T) {
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitClone")
 	assert.NoError(t, err)
@@ -546,7 +548,7 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitCloned")
 	assert.NoError(t, err)
@@ -596,7 +598,7 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitCloned")
 	assert.NoError(t, err)

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -1,5 +1,6 @@
 clusterName: "staging-usw2-k8s"
 syncTimeIntervalMs: 30000
+persistentRepoClonePath: "/tmp"
 autoHealEnabled: true
 cascadeDeletion: false
 includedResources: "group=apps,kind=Deployment;\

--- a/tests/config/testconfig2.yaml
+++ b/tests/config/testconfig2.yaml
@@ -2,3 +2,4 @@ clusterName: "staging-usw2-k8s"
 syncTimeIntervalMs: 30000
 autoHealEnabled: true
 cascadeDeletion: false
+persistentRepoClonePath: "/tmp"

--- a/tests/e2e-gitserver/gitscript.sh
+++ b/tests/e2e-gitserver/gitscript.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#This script is a cgi script that creates the repo using http api
+#curl -X POST -d "name=my_new" http://localhost:8080/create {"status": "success", "message": "Repository 'my_new' created successfully."}
+
+
+read -r repo_name
+repo_name="${repo_name#*=}"
+repo_name=$(echo -e $(echo "$repo_name" | sed "s/+/ /g;s/%\(..\)/\\\\x\1/g;"))
+repo_dir="/var/www/git/${repo_name}.git"
+if  mkdir -p "$repo_dir" && git init --bare "$repo_dir"  > /dev/null 2>&1; then
+    chown -R www-data:www-data "$repo_dir" /dev/null 2>&1
+    echo "Content-Type: application/json"
+        echo ""
+        echo "{\"status\": \"success\", \"message\": \"Repository '${repo_name}' created successfully.\"}"
+    else
+        echo "Content-Type: application/json"
+        echo ""
+        echo "{\"status\": \"error\", \"message\": \"Error: Failed to create repository.\"}"
+fi
+exit 0

--- a/tests/e2e-gitserver/start.sh
+++ b/tests/e2e-gitserver/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+touch /var/log/auth.log
+touch /var/log/apache2/access.log
+touch /var/log/apache2/error.log
+# Starting SSH service
+service ssh start
+tail -F /var/log/apache2/* /var/log/auth.log &
+
+# Run Apache2 in the foreground is important
+apache2ctl -D FOREGROUND


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Yes

Fixes https://github.com/numaproj-labs/numaplane/issues/88

### Modifications

Added a persistent volume and persistent volume claim to the GitSync controller to map the path with the cluster node path or host path. Additionally, modified the git clone process to utilize this persistent volume claim path for cloning repositories.

### Verification

The code has been tested in a local Kind cluster, where the cloned repository is visible in the cluster node's host path. Since the Kind cluster runs inside a Docker container, executing the `docker exec -it` command with shell access allows entry into the host path specified in the PV YAML file.

