### PR TITLE
Sync with git config file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 
 	argoGit "github.com/argoproj/argo-cd/v2/util/git"
@@ -281,6 +282,11 @@ func fetchUpdates(ctx context.Context,
 	pullOptions, err := gitShared.GetRepoPullOptions(ctx, credentials, client, gitSync.Spec.RepoUrl, branch)
 	if err != nil {
 		return err
+	}
+
+	err = gitShared.UpdateOptionsWithGitConfig(config.GlobalScope, pullOptions, gitSync.Spec.RepoUrl)
+	if err != nil {
+		return fmt.Errorf("error updating pull options with git config: %v", err)
 	}
 
 	worktree, err := repo.Worktree()

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -44,6 +44,11 @@ func CloneRepo(
 		return nil, fmt.Errorf("error getting the clone options: %v", err)
 	}
 
+	err = gitShared.UpdateOptionsWithGitConfig(config.GlobalScope, cloneOptions)
+	if err != nil {
+		return nil, fmt.Errorf("error updating clone options with git config: %v", err)
+	}
+
 	return cloneRepo(ctx, gitSync, cloneOptions, metricServer)
 }
 

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -284,7 +284,7 @@ func fetchUpdates(ctx context.Context,
 		return err
 	}
 
-	err = gitShared.UpdateOptionsWithGitConfig(config.GlobalScope, pullOptions, gitSync.Spec.RepoUrl)
+	err = gitShared.UpdateOptionsWithGitConfig(config.GlobalScope, pullOptions)
 	if err != nil {
 		return fmt.Errorf("error updating pull options with git config: %v", err)
 	}

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/storer"
@@ -20,7 +17,6 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/cespare/xxhash/v2"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -476,91 +472,4 @@ func findFirstBranchContainingCommit(repo *git.Repository, commitHash string) (s
 	}
 
 	return firstBranchContainingCommit, nil
-}
-
-// TODO: move below related code into a separate file
-type AuthorizationHeader struct {
-	Key   string
-	Value string
-}
-
-func (h AuthorizationHeader) String() string {
-	return fmt.Sprintf("%s: %s", h.Key, h.Value)
-}
-
-func (h AuthorizationHeader) Name() string {
-	return "extraheader"
-}
-
-func (h AuthorizationHeader) SetAuth(r *http.Request) {
-	r.Header.Set(h.Key, h.Value)
-}
-
-// TODO: instead of passing cloneOptions and fetchOptions, find a way to pass a generic of either of those kinds.
-// Also, consider passing just the repo URL to use for both clone and fetch
-// instead of the specific fetchRemoteURL only for fetch.
-func addProxyOptions(cloneOptions *git.CloneOptions, fetchOptions *git.FetchOptions, fetchRemoteURL string) error {
-	// fmt.Printf("cloneOptions BEFORE: %+v\n", cloneOptions)
-	// fmt.Printf("fetchOptions BEFORE: %+v\n", fetchOptions)
-
-	// TODO: call both GlobalScope and SystemScope OR just ignore SystemScope
-	// and mention in README that the GlobalScope is the only one used.
-	cfg, err := config.LoadConfig(config.GlobalScope)
-	// cfg, err := config.LoadConfig(config.SystemScope)
-	if err != nil {
-		// TODO: instead of returning error, just show an info or warn and do not update the options
-		// because it could mean that .gitconfig was not configured to
-		// use proxy (with or without api gateway [only applies internally to Intuit])
-		return fmt.Errorf("error loading git config: %v", err)
-	}
-
-	authKey := ""
-
-	// Assumption: only focusing on HTTP requests (not SSH)
-	if cloneOptions != nil {
-		// TODO: check error and handle it appropriately
-		repoURL, _ := url.Parse(cloneOptions.URL)
-
-		insteadOf := fmt.Sprintf("%s://%s", repoURL.Scheme, repoURL.Host)
-		for k, v := range cfg.URLs {
-			if v.InsteadOf == insteadOf {
-				cloneOptions.URL = fmt.Sprintf("%s%s", k, repoURL.Path)
-
-				// TODO: check error and handle it appropriately
-				keyURL, _ := url.Parse(k)
-				authKey = fmt.Sprintf("%s://%s", keyURL.Scheme, keyURL.Host)
-				break
-			}
-		}
-	} else if fetchOptions != nil {
-		// TODO: check error and handle it appropriately
-		repoURL, _ := url.Parse(fetchRemoteURL)
-		authKey = fmt.Sprintf("%s://%s", repoURL.Scheme, repoURL.Host)
-	} else {
-		// TODO: this should not happen. Fix after making the func more generic
-		return errors.New("nor clone nor fetch")
-	}
-
-	var authzHeader AuthorizationHeader
-	if httpSection := cfg.Raw.Section("http"); httpSection != nil {
-		if subSection := httpSection.Subsection(authKey); subSection != nil {
-			if option := subSection.Option("extraheader"); strings.HasPrefix(option, "Authorization:") {
-				parts := strings.SplitN(option, ":", 2)
-				authzHeader = AuthorizationHeader{Key: parts[0], Value: parts[1]}
-			}
-		}
-	}
-
-	if cloneOptions != nil {
-		cloneOptions.Auth = authzHeader
-	}
-
-	if fetchOptions != nil {
-		fetchOptions.Auth = authzHeader
-	}
-
-	// fmt.Printf("cloneOptions AFTER: %+v\n", cloneOptions)
-	// fmt.Printf("fetchOptions AFTER: %+v\n", fetchOptions)
-
-	return nil
 }

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -44,7 +44,12 @@ func CloneRepo(
 		return nil, fmt.Errorf("error getting the clone options: %v", err)
 	}
 
-	err = gitShared.UpdateOptionsWithGitConfig(config.GlobalScope, cloneOptions)
+	gitConfig, err := config.LoadConfig(config.GlobalScope)
+	if err != nil {
+		return nil, fmt.Errorf("error loading git config: %v", err)
+	}
+
+	err = gitShared.UpdateOptionsWithGitConfig(gitConfig, cloneOptions)
 	if err != nil {
 		return nil, fmt.Errorf("error updating clone options with git config: %v", err)
 	}
@@ -289,7 +294,12 @@ func fetchUpdates(ctx context.Context,
 		return err
 	}
 
-	err = gitShared.UpdateOptionsWithGitConfig(config.GlobalScope, pullOptions)
+	gitConfig, err := config.LoadConfig(config.GlobalScope)
+	if err != nil {
+		return fmt.Errorf("error loading git config: %v", err)
+	}
+
+	err = gitShared.UpdateOptionsWithGitConfig(gitConfig, pullOptions)
 	if err != nil {
 		return fmt.Errorf("error updating pull options with git config: %v", err)
 	}

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -200,20 +200,18 @@ func UpdateOptionsWithGitConfig[T git.CloneOptions | git.FetchOptions](
 	}
 
 	switch any(*options).(type) {
-	case git.CleanOptions:
-		{
-			insteadOf := fmt.Sprintf("%s://%s", rURL.Scheme, rURL.Host)
-			for k, v := range gitConfig.URLs {
-				if v.InsteadOf == insteadOf {
-					keyURL, err := url.Parse(k)
-					if err != nil {
-						return fmt.Errorf("invalid URL '%s' in git config: %v", k, err)
-					}
-
-					any(*options).(*git.CloneOptions).URL = fmt.Sprintf("%s%s", k, rURL.Path)
-					httpSubSecKey = fmt.Sprintf("%s://%s", keyURL.Scheme, keyURL.Host)
-					break
+	case git.CloneOptions:
+		insteadOf := fmt.Sprintf("%s://%s", rURL.Scheme, rURL.Host)
+		for k, v := range gitConfig.URLs {
+			if v.InsteadOf == insteadOf {
+				keyURL, err := url.Parse(k)
+				if err != nil {
+					return fmt.Errorf("invalid URL '%s' in git config: %v", k, err)
 				}
+
+				any(options).(*git.CloneOptions).URL = fmt.Sprintf("%s%s", k, rURL.Path)
+				httpSubSecKey = fmt.Sprintf("%s://%s", keyURL.Scheme, keyURL.Host)
+				break
 			}
 		}
 	case git.FetchOptions:
@@ -233,10 +231,10 @@ func UpdateOptionsWithGitConfig[T git.CloneOptions | git.FetchOptions](
 
 	if authzHeader != nil {
 		switch any(*options).(type) {
-		case git.CleanOptions:
-			any(*options).(*git.CloneOptions).Auth = authzHeader
+		case git.CloneOptions:
+			any(options).(*git.CloneOptions).Auth = authzHeader
 		case git.FetchOptions:
-			any(*options).(*git.FetchOptions).Auth = authzHeader
+			any(options).(*git.FetchOptions).Auth = authzHeader
 		}
 	}
 

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -200,18 +200,21 @@ func NormalizeGitUrl(gitUrl string) string {
 	return normalizedUrl
 }
 
-// UpdateOptionsWithGitConfig updates the given clone or fetch options object with
-// information loaded from the git config found based on the given config scope.
+// UpdateOptionsWithGitConfig updates the given git options object with
+// information coming from the git config provided.
 // The function only takes into account HTTP URLs (not SSH).
 func UpdateOptionsWithGitConfig[T git.CloneOptions | git.FetchOptions | git.PullOptions](
-	scope config.Scope, options *T,
+	gitConfig *config.Config, options *T,
 ) error {
-	gitConfig, err := config.LoadConfig(scope)
-	if err != nil {
-		return fmt.Errorf("error loading git config: %v", err)
+	if options == nil {
+		return nil
 	}
 
-	// Check if LoadConfig resulted in an empty/new config (maybe because the git config file was not setup)
+	if gitConfig == nil {
+		return nil
+	}
+
+	// If the gitConfig does not include the fields of interest, do not make changes to the options
 	if len(gitConfig.URLs) == 0 && gitConfig.Raw == nil {
 		return nil
 	}

--- a/internal/util/git/git_test.go
+++ b/internal/util/git/git_test.go
@@ -464,7 +464,12 @@ func TestUpdateOptionsWithGitConfigForCloneOptions(t *testing.T) {
 			if err != nil {
 				t.Errorf("error opening gitconfig file '%s': %v", tc.gitConfigFilePath, err)
 			}
-			defer file.Close()
+			defer func() {
+				err := file.Close()
+				if err != nil {
+					t.Errorf("error closing gitconfig file '%s': %v", file.Name(), err)
+				}
+			}()
 
 			gitConfig, err := config.ReadConfig(file)
 			if err != nil {

--- a/internal/util/git/testdata/gitconfig/gitconfig-nourlauth
+++ b/internal/util/git/testdata/gitconfig/gitconfig-nourlauth
@@ -1,0 +1,3 @@
+[user]
+  name = User Name
+  email = username@domain.com

--- a/internal/util/git/testdata/gitconfig/gitconfig-urlonly
+++ b/internal/util/git/testdata/gitconfig/gitconfig-urlonly
@@ -1,0 +1,4 @@
+[url "https://proxy-1.com/v1/proxy"]
+  insteadOf = https://github.mock-1.com
+[url "https://proxy-2.com/v1/proxy"]
+  insteadOf = https://github.mock-2.com

--- a/internal/util/git/testdata/gitconfig/gitconfig-valid
+++ b/internal/util/git/testdata/gitconfig/gitconfig-valid
@@ -1,0 +1,9 @@
+[url "https://proxy-1.com/v1/proxy"]
+  insteadOf = https://github.mock-1.com
+[url "https://proxy-2.com/v1/proxy"]
+  insteadOf = https://github.mock-2.com
+
+[http "https://proxy-1.com"]
+  extraheader = Authorization: token-proxy-1
+[http "https://proxy-2.com"]
+  extraheader = Authorization: token-proxy-2

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -163,7 +163,7 @@ func (nl NumaLogger) WithCallDepth(depth int) NumaLogger {
 
 // Error logs an error with a message and optional key/value pairs.
 func (nl NumaLogger) Error(err error, msg string, keysAndValues ...any) {
-	nl.LogrLogger.Error(err, msg, keysAndValues...)
+	nl.LogrLogger.WithCallDepth(1).Error(err, msg, keysAndValues...)
 }
 
 // Errorf logs an error with a formatted message with args.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj-labs/numaplane/issues/262

### Modifications

Added a function to load the gitconfig file and apply URL mapping and Authorization config options if available for cloning and fetching operations.


### Verification

Tested manually by running the controller on K8s cluster with and without the URL mappings and Authorization extraheader in gitconfig file.
