### PR TITLE
Fetch remote refs during each sync reconcilation

### DIFF
--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/golang/mock/gomock"
@@ -190,11 +189,7 @@ func Test_cloneRepo(t *testing.T) {
 				URL: tc.gitSync.Spec.RepoUrl,
 			}
 
-			fetchOptions := &git.FetchOptions{
-				RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-				Force:    true,
-			}
-			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions, metric)
+			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, metric)
 			assert.NoError(t, cloneErr)
 			if tc.hasErr {
 				assert.NotNil(t, err)
@@ -352,11 +347,8 @@ func Test_GetLatestManifests(t *testing.T) {
 			cloneOptions := &git.CloneOptions{
 				URL: tc.gitSync.Spec.RepoUrl,
 			}
-			fetchOptions := &git.FetchOptions{
-				RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-				Force:    true,
-			}
-			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, fetchOptions, metric)
+
+			r, cloneErr := cloneRepo(context.Background(), tc.gitSync, cloneOptions, metric)
 			assert.Nil(t, cloneErr)
 
 			// To break the continuous check of repo update, added the context timeout.
@@ -458,11 +450,7 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 
 	gitSync := newGitSync("test", repoUrL, "gitClone", "master")
 
-	fetchOptions := &git.FetchOptions{
-		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-		Force:    true,
-	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -493,11 +481,7 @@ func TestGitCloneRepoSshLocalGitServerFileCredential(t *testing.T) {
 
 	gitSync := newGitSync("test", repoUrL, "gitClone", "master")
 
-	fetchOptions := &git.FetchOptions{
-		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-		Force:    true,
-	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -539,11 +523,7 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 	assert.IsType(t, &git.CloneOptions{}, cloneOptions)
 	gitSync := newGitSync("test", repoUrL, "gitCloned", "master")
 
-	fetchOptions := &git.FetchOptions{
-		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-		Force:    true,
-	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
@@ -589,11 +569,7 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 	gitSync := newGitSync("test", repoUrL, "gitCloned", "master")
 	log.Println(cloneOptions)
 
-	fetchOptions := &git.FetchOptions{
-		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-		Force:    true,
-	}
-	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, fetchOptions, metric)
+	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
 	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #258 

### Modifications

This PR fetch remote refs during each sync reconcilation if necessary so switching branches in existing gitsync works.

### Verification
e2e test [here](https://github.com/numaproj-labs/numaplane/commit/f9008a8cfa526405cbacfd1e8a0b88f4a1a7d823) works

