### PR TITLE
update context when loglevel is updated

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -52,6 +52,7 @@ func main() {
 	}
 
 	numaLogger.SetLevel(config.LogLevel)
+	logger.SetBaseLogger(numaLogger)
 
 	numaLogger.Infof("config: %+v", config)
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -56,6 +56,6 @@ func main() {
 	numaLogger.Infof("config: %+v", config)
 
 	// create a new AgentSyncer
-	syncer := agent.NewAgentSyncer(&numaLogger)
+	syncer := agent.NewAgentSyncer(numaLogger)
 	syncer.Run(ctx)
 }

--- a/internal/controller/gitsync_controller.go
+++ b/internal/controller/gitsync_controller.go
@@ -78,7 +78,7 @@ func NewGitSyncReconciler(
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
 func (r *GitSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	numaLogger := logger.FromContext(ctx)
+	ctx, numaLogger := logger.RefreshLogger(ctx)
 
 	// get the GitSync CR - if not found, it may have been deleted in the past
 	gitSync := &apiv1.GitSync{}
@@ -126,8 +126,7 @@ func (r *GitSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 // reconcile does the real logic
 func (r *GitSyncReconciler) reconcile(ctx context.Context, gitSync *apiv1.GitSync) error {
-	ctx, numaLogger := logger.RefreshLogger(ctx)
-	numaLogger = numaLogger.WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name))
+	numaLogger := logger.FromContext(ctx).WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name))
 
 	if !gitSync.Spec.ContainsClusterDestination(r.clusterName) {
 		gitSync.Status.MarkNotApplicable("ClusterMismatch", "This cluster isn't a destination")

--- a/internal/controller/gitsync_controller.go
+++ b/internal/controller/gitsync_controller.go
@@ -126,7 +126,7 @@ func (r *GitSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 // reconcile does the real logic
 func (r *GitSyncReconciler) reconcile(ctx context.Context, gitSync *apiv1.GitSync) error {
-	numaLogger := logger.FromContext(ctx).WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name))
+	numaLogger := logger.RefreshLogger(&ctx).WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name))
 
 	if !gitSync.Spec.ContainsClusterDestination(r.clusterName) {
 		gitSync.Status.MarkNotApplicable("ClusterMismatch", "This cluster isn't a destination")
@@ -155,6 +155,8 @@ func (r *GitSyncReconciler) reconcile(ctx context.Context, gitSync *apiv1.GitSyn
 		numaLogger.Error(err, "Validation failed", "GitSync", gitSync)
 		gitSync.Status.MarkFailed("InvalidSpec", err.Error())
 		return err
+	} else {
+		numaLogger.Debug("validation successful", "GitSync", gitSync)
 	}
 
 	// add Finalizer so we can ensure that we take appropriate action when CRD is deleted

--- a/internal/controller/gitsync_controller.go
+++ b/internal/controller/gitsync_controller.go
@@ -126,7 +126,8 @@ func (r *GitSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 // reconcile does the real logic
 func (r *GitSyncReconciler) reconcile(ctx context.Context, gitSync *apiv1.GitSync) error {
-	numaLogger := logger.RefreshLogger(&ctx).WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name))
+	ctx, numaLogger := logger.RefreshLogger(ctx)
+	numaLogger = numaLogger.WithValues("gitsync", fmt.Sprintf("%s/%s", gitSync.Namespace, gitSync.Name))
 
 	if !gitSync.Spec.ContainsClusterDestination(r.clusterName) {
 		gitSync.Status.MarkNotApplicable("ClusterMismatch", "This cluster isn't a destination")

--- a/internal/controller/gitsync_controller.go
+++ b/internal/controller/gitsync_controller.go
@@ -78,8 +78,10 @@ func NewGitSyncReconciler(
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
 func (r *GitSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// update the Base Logger's level according to the Numaplane Config
 	logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("reconciler").WithValues("gitsync", req.NamespacedName)
+	// update the context with this Logger so downstream users can incorporate these values in the logs
 	ctx = logger.WithLogger(ctx, numaLogger)
 
 	// get the GitSync CR - if not found, it may have been deleted in the past

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -39,7 +39,6 @@ func CloneRepo(
 ) (*git.Repository, error) {
 	numaLogger := logger.FromContext(ctx).WithValues("GitSync name", gitSync.Name, "repo", gitSync.Spec.RepoUrl)
 	gitCredentials := gitShared.FindCredByUrl(gitSync.Spec.RepoUrl, globalConfig)
-	fmt.Printf("deletethis: git credentials associated with URL=%+v\n", gitCredentials)
 	numaLogger.Debugf("git credentials associated with URL=%+v", gitCredentials)
 
 	cloneOptions, err := gitShared.GetRepoCloneOptions(ctx, gitCredentials, client, gitSync.Spec.RepoUrl)

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -38,7 +38,7 @@ func CloneRepo(
 	globalConfig controllerConfig.GlobalConfig,
 	metricServer *metrics.MetricsServer,
 ) (*git.Repository, error) {
-	numaLogger := logger.FromContext(ctx).WithValues("GitSync name", gitSync.Name, "repo", gitSync.Spec.RepoUrl)
+	numaLogger := logger.FromContext(ctx).WithValues("gitSyncName", gitSync.Name, "repo", gitSync.Spec.RepoUrl)
 	gitCredentials := gitShared.FindCredByUrl(gitSync.Spec.RepoUrl, globalConfig)
 	numaLogger.Debugf("git credentials associated with URL=%+v", gitCredentials)
 

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -37,7 +37,11 @@ func CloneRepo(
 	globalConfig controllerConfig.GlobalConfig,
 	metricServer *metrics.MetricsServer,
 ) (*git.Repository, error) {
+	numaLogger := logger.FromContext(ctx).WithValues("GitSync name", gitSync.Name, "repo", gitSync.Spec.RepoUrl)
 	gitCredentials := gitShared.FindCredByUrl(gitSync.Spec.RepoUrl, globalConfig)
+	fmt.Printf("deletethis: git credentials associated with URL=%+v\n", gitCredentials)
+	numaLogger.Debugf("git credentials associated with URL=%+v", gitCredentials)
+
 	cloneOptions, err := gitShared.GetRepoCloneOptions(ctx, gitCredentials, client, gitSync.Spec.RepoUrl)
 	if err != nil {
 		return nil, fmt.Errorf("error getting  the  clone options: %v", err)

--- a/internal/sync/cache.go
+++ b/internal/sync/cache.go
@@ -110,7 +110,7 @@ func newLiveStateCache(
 	numaLogger := logger.New().WithName("live state cache")
 	return &liveStateCache{
 		cluster: cluster,
-		logger:  &numaLogger,
+		logger:  numaLogger,
 	}
 }
 

--- a/internal/sync/options.go
+++ b/internal/sync/options.go
@@ -11,7 +11,7 @@ type Option func(*options)
 
 func defaultOptions() *options {
 	return &options{
-		workers:      1, //20,
+		workers:      20,
 		taskInterval: 30000,
 	}
 }

--- a/internal/sync/options.go
+++ b/internal/sync/options.go
@@ -11,7 +11,7 @@ type Option func(*options)
 
 func defaultOptions() *options {
 	return &options{
-		workers:      20,
+		workers:      1, //20,
 		taskInterval: 30000,
 	}
 }

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -205,7 +205,8 @@ func (s *Syncer) run(ctx context.Context, id int, keyCh <-chan string) {
 // Function runOnce implements the logic of each synchronization.
 func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 
-	numaLogger := logger.RefreshLogger(&ctx).WithValues("worker", worker, "gitSyncKey", key)
+	ctx, numaLogger := logger.RefreshLogger(ctx)
+	numaLogger = numaLogger.WithValues("worker", worker, "gitSyncKey", key)
 
 	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()
 	if err != nil {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -205,16 +205,12 @@ func (s *Syncer) run(ctx context.Context, id int, keyCh <-chan string) {
 // Function runOnce implements the logic of each synchronization.
 func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 
-	numaLogger := logger.FromContext(ctx).WithValues("worker", worker, "gitSyncKey", key)
-	//numaLogger.Debug("deletethis: test 1")
+	numaLogger := logger.RefreshLogger(ctx).WithValues("worker", worker, "gitSyncKey", key)
+
 	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()
 	if err != nil {
 		numaLogger.Error(err, "error getting the global config")
 	}
-
-	numaLogger.SetLevel(globalConfig.LogLevel)
-	numaLogger.Infof("New log level=%d\n", globalConfig.LogLevel)
-	ctx = logger.WithLogger(ctx, numaLogger)
 
 	// startTime used for calculating metrics
 	startTime := time.Now()

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -213,7 +213,7 @@ func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 	}
 
 	numaLogger.SetLevel(globalConfig.LogLevel)
-	numaLogger.Debugf("New log level=%d\n", globalConfig.LogLevel)
+	numaLogger.Infof("New log level=%d\n", globalConfig.LogLevel)
 	ctx = logger.WithLogger(ctx, numaLogger)
 
 	// startTime used for calculating metrics

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -205,21 +205,16 @@ func (s *Syncer) run(ctx context.Context, id int, keyCh <-chan string) {
 // Function runOnce implements the logic of each synchronization.
 func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 
-	fmt.Printf("deletethis: ctx=%+v\n", ctx)
 	numaLogger := logger.FromContext(ctx).WithValues("worker", worker, "gitSyncKey", key)
-	fmt.Printf("deletethis: before numaLogger=%+v\n", *numaLogger.LogrLogger)
-	numaLogger.Debug("deletethis: prior to updating")
-	numaLogger.Debugf("deletethis: Debugf call\n")
+	//numaLogger.Debug("deletethis: test 1")
 	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()
 	if err != nil {
 		numaLogger.Error(err, "error getting the global config")
 	}
 
 	numaLogger.SetLevel(globalConfig.LogLevel)
-	fmt.Printf("deletethis: after setting level numaLogger=%+v\n", *numaLogger.LogrLogger)
-	fmt.Printf("deletethis: level=%d\n", globalConfig.LogLevel)
+	numaLogger.Debugf("New log level=%d\n", globalConfig.LogLevel)
 	ctx = logger.WithLogger(ctx, numaLogger)
-	fmt.Printf("deletethis: after context numaLogger=%+v\n", logger.FromContext(ctx).LogrLogger)
 
 	// startTime used for calculating metrics
 	startTime := time.Now()

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -205,7 +205,7 @@ func (s *Syncer) run(ctx context.Context, id int, keyCh <-chan string) {
 // Function runOnce implements the logic of each synchronization.
 func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 
-	numaLogger := logger.RefreshLogger(ctx).WithValues("worker", worker, "gitSyncKey", key)
+	numaLogger := logger.RefreshLogger(&ctx).WithValues("worker", worker, "gitSyncKey", key)
 
 	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()
 	if err != nil {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -208,8 +208,10 @@ func (s *Syncer) run(ctx context.Context, id int, keyCh <-chan string) {
 // Function runOnce implements the logic of each synchronization.
 func (s *Syncer) runOnce(ctx context.Context, key string, worker int) error {
 
+	// update the Base Logger's level according to the Numaplane Config
 	logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("synchronizer").WithValues("worker", worker, "gitSyncKey", key)
+	// update the context with this Logger so downstream users can incorporate these values in the logs
 	ctx = logger.WithLogger(ctx, numaLogger)
 
 	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -126,6 +126,9 @@ func (s *Syncer) StopWatching(key string) {
 // Each worker keeps picking up tasks (which contains GitSync keys) to sync the resources.
 func (s *Syncer) Start(ctx context.Context) error {
 	numaLogger := logger.FromContext(ctx).WithName("synchronizer")
+	logger.WithLogger(ctx, numaLogger)
+	ctx, numaLogger = logger.RefreshLogger(ctx) // refresh log level to what's in the config
+
 	numaLogger.Info("Starting synchronizer...")
 
 	keyCh := make(chan string)

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -41,7 +41,6 @@ func GetAuthMethod(ctx context.Context, repoCred *apiv1.RepoCredential, kubeClie
 		case "http", "https":
 			if cred := repoCred.HTTPCredential; cred != nil {
 				numaLogger.Debugf("using HTTP credential: %+v", repoCred.HTTPCredential)
-				fmt.Printf("deletethis: using HTTP credential: %+v\n", repoCred.HTTPCredential)
 				password, err := getSecretValue(ctx, kubeClient, cred.Password)
 				if err != nil {
 					return nil, false, fmt.Errorf("failed to get HTTP credential: %w", err)
@@ -56,7 +55,6 @@ func GetAuthMethod(ctx context.Context, repoCred *apiv1.RepoCredential, kubeClie
 		case "ssh":
 			if cred := repoCred.SSHCredential; cred != nil {
 				numaLogger.Debugf("using SSH credential: %+v", repoCred.SSHCredential)
-				fmt.Printf("deletethis: using SSH credential: %+v\n", repoCred.SSHCredential)
 				sshKey, err := getSecretValue(ctx, kubeClient, cred.SSHKey)
 				if err != nil {
 					return nil, false, fmt.Errorf("Failed to get SSH credential: %w", err)
@@ -90,14 +88,12 @@ func getSecretValue(ctx context.Context, kubeClient k8sClient.Client, secretSour
 			return "", fmt.Errorf("failed to get secret %+v from K8S Secret: %w", *secretSource.FromKubernetesSecret, err)
 		}
 		numaLogger.Debugf("Successfully got secret %+v from K8S Secret", *secretSource.FromKubernetesSecret)
-		fmt.Printf("deletethis: Successfully got secret %+v from K8S Secret\n", *secretSource.FromKubernetesSecret)
 	} else if secretSource.FromFile != nil {
 		secretValue, err = secretSource.FromFile.GetSecretValue()
 		if err != nil {
 			return "", fmt.Errorf("failed to get secret %+v from file: %w", *secretSource.FromFile, err)
 		}
 		numaLogger.Debugf("Successfully got secret %+v from file", *secretSource.FromFile)
-		fmt.Printf("deletethis: Successfully got secret %+v from file\n", *secretSource.FromFile)
 	} else {
 		return "", fmt.Errorf("invalid SecretSource: either FromKubernetesSecret or FromFile should be specified: %+v", secretSource)
 	}

--- a/internal/util/logger/base_logger.go
+++ b/internal/util/logger/base_logger.go
@@ -1,0 +1,51 @@
+package logger
+
+import (
+	"sync"
+
+	controllerConfig "github.com/numaproj-labs/numaplane/internal/controller/config"
+)
+
+// Singleton Base Logger from which other loggers can be derived
+// maintains current log level for the application as a whole
+
+var (
+	baseLogger      *NumaLogger = New()
+	baseLoggerMutex sync.RWMutex
+)
+
+// SetBaseLogger is intended to be set once when application starts
+func SetBaseLogger(nl *NumaLogger) {
+	baseLoggerMutex.Lock()
+	defer baseLoggerMutex.Unlock()
+
+	baseLogger = nl.DeepCopy()
+}
+
+// Get the standard NumaLogger with current Log Level - deep copy it in case user modifies it
+func GetBaseLogger() *NumaLogger {
+	baseLoggerMutex.RLock()
+	defer baseLoggerMutex.RUnlock()
+	return baseLogger.DeepCopy()
+}
+
+// Refresh the Logger's LogLevel based on current config value
+func RefreshBaseLoggerLevel() {
+
+	// get the log level from the config
+	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()
+	if err != nil {
+		baseLogger.Error(err, "error getting the global config")
+	}
+
+	// if it changed, propagate it to our Base Logger
+	if globalConfig.LogLevel != baseLogger.LogLevel {
+
+		baseLoggerMutex.Lock()
+		defer baseLoggerMutex.Unlock()
+
+		// update the logger with the new log level
+		baseLogger.SetLevel(globalConfig.LogLevel)
+		baseLogger.Infof("log level=%d\n", globalConfig.LogLevel)
+	}
+}

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -240,8 +240,6 @@ func (nl *NumaLogger) Infof(msg string, args ...any) {
 // Debug logs a debug-level message with optional key/value pairs.
 func (nl *NumaLogger) Debug(msg string, keysAndValues ...any) {
 	// NOTE: -infoLevelShift is needed to offset the `level += infoLevelShift` in the LogSink Info implementation
-	//fmt.Printf("deletethis: is level 1 enabled?: %v\n", nl.LogrLogger.GetSink().Enabled(1))
-
 	nl.LogrLogger.GetSink().Info(DebugLevel-infoLevelShift, msg, keysAndValues...)
 }
 

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -135,11 +135,10 @@ func WithLogger(ctx context.Context, logger *NumaLogger) context.Context {
 // If there is no logger in context, a new one is created.
 func FromContext(ctx context.Context) *NumaLogger {
 	if logger, ok := ctx.Value(loggerKey).(*NumaLogger); ok {
-		fmt.Printf("deletethis: found logger: %+v\n", logger.LogrLogger)
+		//fmt.Printf("deletethis: found logger.LogrLogger: %+v\n", logger.LogrLogger)
 		return logger
 	}
 
-	fmt.Printf("deletethis: didn't find logger\n")
 	return New()
 }
 
@@ -213,7 +212,7 @@ func (nl *NumaLogger) Infof(msg string, args ...any) {
 // Debug logs a debug-level message with optional key/value pairs.
 func (nl *NumaLogger) Debug(msg string, keysAndValues ...any) {
 	// NOTE: -infoLevelShift is needed to offset the `level += infoLevelShift` in the LogSink Info implementation
-	fmt.Printf("deletethis: is level 1 enabled?: %v\n", nl.LogrLogger.GetSink().Enabled(1))
+	//fmt.Printf("deletethis: is level 1 enabled?: %v\n", nl.LogrLogger.GetSink().Enabled(1))
 
 	nl.LogrLogger.GetSink().Info(DebugLevel-infoLevelShift, msg, keysAndValues...)
 }

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -58,9 +58,7 @@ var logrVerbosityToZerologLevelMap = map[int]zerolog.Level{
 	VerboseLevel: -2,
 }
 
-var (
-	loggerKey = "logger"
-)
+type loggerKey struct{}
 
 // NumaLogger is the struct containing a pointer to a logr.Logger instance.
 type NumaLogger struct {
@@ -128,13 +126,13 @@ func newNumaLogger(writer *io.Writer, level *int) *NumaLogger {
 // WithLogger returns a copy of parent context in which the
 // value associated with logger key is the supplied logger.
 func WithLogger(ctx context.Context, logger *NumaLogger) context.Context {
-	return context.WithValue(ctx, loggerKey, logger)
+	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
 // FromContext returns the logger in the context.
 // If there is no logger in context, a new one is created.
 func FromContext(ctx context.Context) *NumaLogger {
-	if logger, ok := ctx.Value(loggerKey).(*NumaLogger); ok {
+	if logger, ok := ctx.Value(loggerKey{}).(*NumaLogger); ok {
 		//fmt.Printf("deletethis: found logger.LogrLogger: %+v\n", logger.LogrLogger)
 		return logger
 	}

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -135,7 +135,6 @@ func WithLogger(ctx context.Context, logger *NumaLogger) context.Context {
 // If there is no logger in context, a new one is created.
 func FromContext(ctx context.Context) *NumaLogger {
 	if logger, ok := ctx.Value(loggerKey{}).(*NumaLogger); ok {
-		//fmt.Printf("deletethis: found logger.LogrLogger: %+v\n", logger.LogrLogger)
 		return logger.DeepCopy()
 	}
 

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -146,6 +146,7 @@ func (in *NumaLogger) DeepCopy() *NumaLogger {
 		return nil
 	}
 	out := new(NumaLogger)
+	out.LogLevel = in.LogLevel
 	out.LogrLogger = new(logr.Logger)
 	*(out.LogrLogger) = *(in.LogrLogger)
 	return out
@@ -153,24 +154,27 @@ func (in *NumaLogger) DeepCopy() *NumaLogger {
 
 // WithName appends a given name to the logger.
 func (nl *NumaLogger) WithName(name string) *NumaLogger {
+	out := *nl
 	ll := nl.LogrLogger.WithName(name)
-	nl.LogrLogger = &ll
-	return nl
+	out.LogrLogger = &ll
+	return &out
 }
 
 // WithValues appends additional key/value pairs to the logger.
 func (nl *NumaLogger) WithValues(keysAndValues ...any) *NumaLogger {
+	out := *nl
 	ll := nl.LogrLogger.WithValues(keysAndValues)
-	nl.LogrLogger = &ll
-	return nl
+	out.LogrLogger = &ll
+	return &out
 }
 
 // WithCallDepth returns a Logger instance that offsets the call stack by the
 // specified number of frames when logging call site information.
 func (nl *NumaLogger) WithCallDepth(depth int) *NumaLogger {
+	out := *nl
 	ll := nl.LogrLogger.WithCallDepth(depth)
-	nl.LogrLogger = &ll
-	return nl
+	out.LogrLogger = &ll
+	return &out
 }
 
 // Error logs an error with a message and optional key/value pairs.

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/numaproj-labs/numaplane/internal/common"
+
+	controllerConfig "github.com/numaproj-labs/numaplane/internal/controller/config"
 	"github.com/rs/zerolog"
 )
 
@@ -138,6 +140,20 @@ func FromContext(ctx context.Context) *NumaLogger {
 	}
 
 	return New()
+}
+
+func RefreshLogger(ctx context.Context) *NumaLogger {
+	numaLogger := FromContext(ctx)
+	//numaLogger.Debug("deletethis: test 1")
+	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()
+	if err != nil {
+		numaLogger.Error(err, "error getting the global config")
+	}
+
+	numaLogger.SetLevel(globalConfig.LogLevel)
+	numaLogger.Infof("New log level=%d\n", globalConfig.LogLevel)
+	ctx = WithLogger(ctx, numaLogger)
+	return numaLogger
 }
 
 // WithName appends a given name to the logger.

--- a/internal/util/logger/logger_test.go
+++ b/internal/util/logger/logger_test.go
@@ -20,7 +20,7 @@ type LogJSON struct {
 	FieldB  string `json:"fieldB,omitempty"`
 }
 
-func mock(level *int) (NumaLogger, *bytes.Buffer) {
+func mock(level *int) (*NumaLogger, *bytes.Buffer) {
 	var buf bytes.Buffer
 	w := io.Writer(&buf)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Motivation

We are using the [context to get the Logger](https://github.com/numaproj-labs/numaplane/blob/v0.1.2/internal/sync/syncer.go#L117), but we don't ever update the context to reflect that the Logger changed.


### Modifications

I added a Base Logger for the application, which is essentially the original Logger but with the Log level periodically updated based on the Config. 

Long living goroutines periodically refresh the Base Logger with the current log level and get a copy of it, add any Values they want logged, and then update the context to include that Logger, so downstream users will log those same values automatically. 


### Verification

Updated logLevel from `info` to `debug` level back and forth, and witnessed the log lines change. Verified for both calls in `syncer.runOnce()`, calls from functions called downstream of `syncer.runOnce()` for which `context` got passed as argument, and from `Reconcile()`.

### Remaining work

1. We're still not updating the LogrLogger log level passed to the underlying cache in gitops-engine. That is constructed [here](https://github.com/numaproj-labs/numaplane/blob/main/internal/sync/cache.go#L184) and never gets updated. This is the one place where the logging is still not changing if you look at the log lines.
2. [This](https://github.com/numaproj-labs/numaplane/issues/189) issue still exists. It takes a couple of cycles for the log level to change where it does work.
