### PR TITLE
test: e2e test case for using branches other than main/master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ start-e2e: numaflow-crd cleanup-e2e image
 test-e2e:
 test-%: start-e2e
 	go generate $(shell find ./tests/$* -name '*.go')
-	go test -v -timeout 15m -count 1 --tags test -p 1 ./tests/$*
+	go test -v -timeout 20m -count 1 --tags test -p 1 ./tests/$*
 	$(MAKE) cleanup-e2e
 
 numaflow-crd:

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -281,6 +281,38 @@ func (s *FunctionalSuite) TestHelm() {
 
 }
 
+func (s *FunctionalSuite) TestNonMainBranch() {
+
+	// start at master branch
+	w := s.Given().GitSync("@testdata/gitsync.yaml").InitializeGitRepo("basic-resources/initial-commit").
+		When().
+		CreateGitSyncAndWait()
+	defer w.DeleteGitSyncAndWait()
+
+	// verify basics resources are created
+	w.Wait(30 * time.Second)
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"test-deploy"})
+	w.Expect().ResourcesExist("v1", "configmaps", []string{"test-config"})
+	w.Expect().ResourcesExist("v1", "secrets", []string{"test-secret"})
+	// these resources are defined in the same file
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"multi-deploy"})
+	w.Expect().ResourcesExist("v1", "configmaps", []string{"multi-config"})
+	w.Expect().CheckCommitStatus()
+
+	// switch to test branch
+	w = s.Given().GitSync("@testdata/branch-gitsync.yaml").ChangeBranch().
+		When().
+		UpdateGitSyncAndWait()
+
+	w.Wait(30 * time.Second)
+
+	// update deployment manifest with {replicas: 5}
+	w.PushToGitRepo("basic-resources/modified", []string{"deployment.yaml"}, false).Wait(30 * time.Second)
+	w.Expect().ResourcesExist("apps/v1", "deployments", []string{"test-deploy"})
+	w.Expect().CheckCommitStatus()
+
+}
+
 func TestFunctionalSuite(t *testing.T) {
 	suite.Run(t, new(FunctionalSuite))
 }

--- a/tests/e2e/testdata/branch-gitsync.yaml
+++ b/tests/e2e/testdata/branch-gitsync.yaml
@@ -1,0 +1,13 @@
+apiVersion: numaplane.numaproj.io/v1alpha1
+kind: GitSync
+metadata:
+  name: gitsync-example
+  namespace: numaplane-system
+spec:
+  path: "sample-manifests"
+  repoUrl: http://localgitserver-service.numaplane-system.svc.cluster.local/git/repo1.git
+  targetRevision: test
+  raw: {}
+  destination:
+    cluster: staging-usw2-k8s
+    namespace: numaplane-e2e

--- a/tests/fixtures/given.go
+++ b/tests/fixtures/given.go
@@ -215,6 +215,8 @@ func (g *Given) InitializeGitRepo(directory string) *Given {
 
 func (g *Given) ChangeBranch() *Given {
 
+	g.t.Log("Checking out different branch..")
+
 	repoNum := TrimRepoUrl(g.gitSync.Spec.RepoUrl)
 	localPathToRepo := filepath.Join(localPath, repoNum)
 
@@ -232,12 +234,12 @@ func (g *Given) ChangeBranch() *Given {
 
 	err = wt.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName(g.gitSync.Spec.TargetRevision),
-		Create: true,
 	})
 	if err != nil {
-		if err == git.ErrBranchExists {
+		if strings.Contains(err.Error(), "reference not found") {
 			err = wt.Checkout(&git.CheckoutOptions{
 				Branch: plumbing.NewBranchReferenceName(g.gitSync.Spec.TargetRevision),
+				Create: true,
 			})
 			if err != nil {
 				g.t.Fatal(err)
@@ -246,6 +248,8 @@ func (g *Given) ChangeBranch() *Given {
 			g.t.Fatal(err)
 		}
 	}
+
+	g.t.Logf("Successfully checked out branch %s", g.gitSync.Spec.TargetRevision)
 
 	return g
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #248 

### Modifications

Adds test case called `TestNonMainBranch` to test that GitSync works properly when `targetRevision` is set to a branch other than main or master. This done by creating a new branch `test` and pushing to it to see that changes on the resources are reflected by it. We also test changing back to the master branch.


### Verification

Ran `make test-e2e`

