### PR TITLE
fixed public git repo serve for apache server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,6 @@ $(ENVTEST): $(LOCALBIN)
 gitserver:
 		cd tests/gitserver && \
 		 docker buildx build \
-		--no-cache \
 		--build-arg REPO_COUNT=$(REPO_COUNT) \
 		--platform $(PLATFORMS) \
 		-t $(GITSERVER_IMAGE) \

--- a/tests/gitserver/Dockerfile
+++ b/tests/gitserver/Dockerfile
@@ -46,7 +46,7 @@ RUN for i in $(seq 1 $REPO_COUNT); do \
     chmod +x "/var/www/git/repo$i.git/hooks/post-receive"; \
     done
 
-#creating repositories which donot require authentication and can be accessed from http://localhost:8080/public-git
+#creating repositories which don't require authentication and can be accessed from http://localhost:8080/public-git
 RUN for i in $(seq 1 $REPO_COUNT); do \
     mkdir -p "/var/www/public-git/repo$i.git" && \
     git init --bare "/var/www/public-git/repo$i.git" && \
@@ -62,19 +62,24 @@ RUN mkdir /auth && \
     echo "<VirtualHost *:80>\n\
     SetEnv GIT_PROJECT_ROOT /var/www/git\n\
     SetEnv GIT_HTTP_EXPORT_ALL\n\
+    SetEnv REMOTE_USER=$REDIRECT_REMOTE_USER\n\
     ScriptAlias /git/ /usr/lib/git-core/git-http-backend/\n\
     ScriptAlias /public-git/ /usr/lib/git-core/git-http-backend/\n\
     ScriptAlias /create /usr/lib/cgi-bin/create_repo.cgi\n\
+    <Directory /usr/lib/git-core>\n\
+            Options +ExecCGI\n\
+            Require all granted\n\
+        </Directory>\n\
     <Location /git>\n\
     AuthType Basic\n\
     AuthName \"Git Access\"\n\
     AuthUserFile /auth/.htpasswd\n\
     Require valid-user\n\
     </Location>\n\
-    <Location /public-git >\n\
-        Satisfy Any\n\
-        Allow from all\n\
-    </Location>\n\
+     <LocationMatch \"^/public-git/.*\">\n\
+          Satisfy Any\n\
+          Allow from all\n\
+        </LocationMatch>\n\
     </VirtualHost>\n\
     <VirtualHost *:443>\n\
     SSLEngine on\n\
@@ -90,10 +95,10 @@ RUN mkdir /auth && \
     AuthUserFile /auth/.htpasswd\n\
     Require valid-user\n\
     </Location>\n\
-     <Location /public-git >\n\
-        Satisfy Any\n\
-        Allow from all\n\
-    </Location>\n\
+     <LocationMatch \"^/public-git/.*\">\n\
+          Satisfy Any\n\
+          Allow from all\n\
+        </LocationMatch>\n\
     </VirtualHost>" > /etc/apache2/sites-available/000-default.conf
 
 
@@ -122,7 +127,7 @@ RUN for i in $(seq 1 $REPO_COUNT); do \
 #to access http://localhost:8080/git/repo2.git http://localhost:8080/git/repo1.git
 
 
-# Creating a non bare git repo  which donot require  authentication with working directory as per the RepoCount variable and pushing the changes
+# Creating a non bare git repo  which don't require  authentication with working directory as per the RepoCount variable and pushing the changes
 # to the bare repository created in /var/www/git
 RUN for i in $(seq 1 $REPO_COUNT); do \
     mkdir /tmp/public-git-repo$i && \

--- a/tests/gitserver/Dockerfile
+++ b/tests/gitserver/Dockerfile
@@ -46,14 +46,14 @@ RUN for i in $(seq 1 $REPO_COUNT); do \
     chmod +x "/var/www/git/repo$i.git/hooks/post-receive"; \
     done
 
-#creating repositories which donot require authentication and can be accessed from http://localhost:8080/gitopen
+#creating repositories which donot require authentication and can be accessed from http://localhost:8080/public-git
 RUN for i in $(seq 1 $REPO_COUNT); do \
-    mkdir -p "/var/www/gitopen/repo$i.git" && \
-    git init --bare "/var/www/gitopen/repo$i.git" && \
-    chown -R www-data:www-data "/var/www/gitopen/repo$i.git"; \
-    echo "#!/bin/sh" > "/var/www/gitopen/repo$i.git/hooks/post-receive" && \
-    echo "chown -R www-data:www-data ." >> "/var/www/gitopen/repo$i.git/hooks/post-receive" && \
-    chmod +x "/var/www/gitopen/repo$i.git/hooks/post-receive"; \
+    mkdir -p "/var/www/public-git/repo$i.git" && \
+    git init --bare "/var/www/public-git/repo$i.git" && \
+    chown -R www-data:www-data "/var/www/public-git/repo$i.git"; \
+    echo "#!/bin/sh" > "/var/www/public-git/repo$i.git/hooks/post-receive" && \
+    echo "chown -R www-data:www-data ." >> "/var/www/public-git/repo$i.git/hooks/post-receive" && \
+    chmod +x "/var/www/public-git/repo$i.git/hooks/post-receive"; \
     done
 
 # Setup Apache for Git HTTP and HTTPS access with Basic authentication
@@ -63,7 +63,7 @@ RUN mkdir /auth && \
     SetEnv GIT_PROJECT_ROOT /var/www/git\n\
     SetEnv GIT_HTTP_EXPORT_ALL\n\
     ScriptAlias /git/ /usr/lib/git-core/git-http-backend/\n\
-    ScriptAlias /gitopen/ /usr/lib/git-core/git-http-backend/\n\
+    ScriptAlias /public-git/ /usr/lib/git-core/git-http-backend/\n\
     ScriptAlias /create /usr/lib/cgi-bin/create_repo.cgi\n\
     <Location /git>\n\
     AuthType Basic\n\
@@ -71,10 +71,10 @@ RUN mkdir /auth && \
     AuthUserFile /auth/.htpasswd\n\
     Require valid-user\n\
     </Location>\n\
-    <LocationMatch \"^/gitopen\">\n\
+    <Location /public-git >\n\
         Satisfy Any\n\
         Allow from all\n\
-    </LocationMatch>\n\
+    </Location>\n\
     </VirtualHost>\n\
     <VirtualHost *:443>\n\
     SSLEngine on\n\
@@ -83,17 +83,17 @@ RUN mkdir /auth && \
     SetEnv GIT_PROJECT_ROOT /var/www/git\n\
     SetEnv GIT_HTTP_EXPORT_ALL\n\
     ScriptAlias /git/ /usr/lib/git-core/git-http-backend/\n\
-    ScriptAlias /gitopen/ /usr/lib/git-core/git-http-backend/\n\
+    ScriptAlias /public-git/ /usr/lib/git-core/git-http-backend/\n\
     <Location /git>\n\
     AuthType Basic\n\
     AuthName \"Git Access\"\n\
     AuthUserFile /auth/.htpasswd\n\
     Require valid-user\n\
     </Location>\n\
-     <LocationMatch \"^/gitopen\">\n\
+     <Location /public-git >\n\
         Satisfy Any\n\
         Allow from all\n\
-    </LocationMatch>\n\
+    </Location>\n\
     </VirtualHost>" > /etc/apache2/sites-available/000-default.conf
 
 
@@ -125,17 +125,17 @@ RUN for i in $(seq 1 $REPO_COUNT); do \
 # Creating a non bare git repo  which donot require  authentication with working directory as per the RepoCount variable and pushing the changes
 # to the bare repository created in /var/www/git
 RUN for i in $(seq 1 $REPO_COUNT); do \
-    mkdir /tmp/gitopen-repo$i && \
-    cd /tmp/gitopen-repo$i && \
+    mkdir /tmp/public-git-repo$i && \
+    cd /tmp/public-git-repo$i && \
     git init && \
     git config --global user.email "you@example.com" && \
     git config --global user.name "Your Name" && \
     echo "Local Repo" > readme.md && \
     git add readme.md && \
     git commit -m "Initial commit" && \
-    git push /var/www/gitopen/repo$i.git master;\
+    git push /var/www/public-git/repo$i.git master;\
     done
-#to access http://localhost:8080/gitopen/repo2.git http://localhost:8080/gitopen/repo1.git
+#to access http://localhost:8080/public-git/repo2.git http://localhost:8080/public-git/repo1.git
 
 # Copy the start script into the container and set permissions
 COPY start.sh /start.sh

--- a/tests/gitserver/Dockerfile
+++ b/tests/gitserver/Dockerfile
@@ -30,6 +30,7 @@ RUN a2enmod ssl && \
     a2ensite default-ssl
 
 
+
 # this ownership part is important such that we can be able to create git repos with the api by making the www-data user the owner of the folder
 RUN mkdir -p /var/www/git && \
     chown -R www-data:www-data /var/www/git


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Yes

Fixes  https://github.com/numaproj-labs/numaplane/issues/270

### Modifications
I had to modify the Apache server configuration for LocalGitServer because there was an issue resolving public Git URLs. The location matching for `/gitopen` was getting redirected to '/git', which requires authentication, so I changed `/gitopen` to `/public-git`. 

### Verification

Tests running on local cluster and unit tests


