### PR TITLE
Persistent volume For cloning Repository in Gitsync

### DIFF
--- a/config/manager/persistent-volume-claim.yaml
+++ b/config/manager/persistent-volume-claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: numaplane-repo-pvc
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/config/manager/persistent-volume.yaml
+++ b/config/manager/persistent-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: numaplane-repo-pv
+  labels:
+    type: local
+spec:
+  storageClassName: standard
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+      path: "/tmp"

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -41,8 +41,9 @@ type GlobalConfig struct {
 	AutoHealDisabled      bool   `json:"autoHealDisabled" mapstructure:"autoHealDisabled"`
 	IncludedResources     string `json:"includedResources" mapstructure:"includedResources"`
 	// RepoCredentials maps each Git Repository Path prefix to the corresponding credentials that are needed for it
-	RepoCredentials []apiv1.RepoCredential `json:"repoCredentials" mapstructure:"repoCredentials"`
-	LogLevel        int                    `json:"logLevel" mapstructure:"logLevel"`
+	RepoCredentials         []apiv1.RepoCredential `json:"repoCredentials" mapstructure:"repoCredentials"`
+	LogLevel                int                    `json:"logLevel" mapstructure:"logLevel"`
+	PersistentRepoClonePath string                 `json:"persistentRepoClonePath" mapstructure:"persistentRepoClonePath"`
 }
 
 func (cm *ConfigManager) GetConfig() (GlobalConfig, error) {

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -30,6 +30,7 @@ func TestLoadConfigMatchValues(t *testing.T) {
 	assert.Nil(t, err, "Failed to load configuration")
 
 	assert.Equal(t, "staging-usw2-k8s", config.ClusterName, "ClusterName does not match")
+	assert.Equal(t, "/tmp", config.PersistentRepoClonePath, "ClusterName does not match")
 	assert.Equal(t, 30000, config.SyncTimeIntervalMs, "SyncTimeIntervalMs does not match")
 	assert.Equal(t, false, config.AutoHealDisabled, "AutoHealDisabled does not match")
 	assert.Equal(t, false, config.AutomatedSyncDisabled, "AutomatedSyncDisabled does not match")

--- a/internal/git/util.go
+++ b/internal/git/util.go
@@ -82,7 +82,10 @@ func GetLatestManifests(
 		return "", nil, err
 	}
 
-	localRepoPath := getLocalRepoPath(gitSync)
+	localRepoPath, err := getLocalRepoPath(gitSync)
+	if err != nil {
+		return "", nil, err
+	}
 
 	// deployablePath will be the path of cloned repository + the path while needs to be deployed.
 	deployablePath := localRepoPath + "/" + gitSync.Spec.Path
@@ -220,14 +223,18 @@ func isRootDir(path string) bool {
 // getLocalRepoPath will return the local path where repo will be cloned,
 // by default it will use /tmp as base directory
 // unless LOCAL_REPO_PATH env is set.
-func getLocalRepoPath(gitSync *v1alpha1.GitSync) string {
-	baseDir := os.Getenv("LOCAL_REPO_PATH")
-	repoUrl := strconv.FormatUint(xxhash.Sum64([]byte(gitSync.Spec.RepoUrl)), 16)
-	if baseDir != "" {
-		return fmt.Sprintf("%s/%s/%s", baseDir, gitSync.Name, repoUrl)
-	} else {
-		return fmt.Sprintf("/tmp/%s/%s", gitSync.Name, repoUrl)
+func getLocalRepoPath(gitSync *v1alpha1.GitSync) (string, error) {
+	// baseDir is persistent volume path on the cluster node
+	baseDir := "/tmp"
+	globalConfig, err := controllerConfig.GetConfigManagerInstance().GetConfig()
+	if err != nil {
+		return "", fmt.Errorf("error getting config manager for repoLocalPath %s", err)
 	}
+	if globalConfig.PersistentRepoClonePath != "" {
+		baseDir = globalConfig.PersistentRepoClonePath
+	}
+	repoUrl := strconv.FormatUint(xxhash.Sum64([]byte(gitSync.Spec.RepoUrl)), 16)
+	return fmt.Sprintf("%s/%s/%s", baseDir, gitSync.Name, repoUrl), nil
 }
 
 func GetCurrentBranch(r *git.Repository) (string, error) {
@@ -328,7 +335,10 @@ func cloneRepo(
 	cloneOptions *git.CloneOptions,
 	metricServer *metrics.MetricsServer,
 ) (*git.Repository, error) {
-	path := getLocalRepoPath(gitSync)
+	path, err := getLocalRepoPath(gitSync)
+	if err != nil {
+		return nil, err
+	}
 	defer func() {
 		metricServer.IncGitRequest()
 	}()

--- a/internal/git/util_test.go
+++ b/internal/git/util_test.go
@@ -182,8 +182,9 @@ func Test_cloneRepo(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync)
-			err := os.RemoveAll(localRepoPath)
+			localRepoPath, err := getLocalRepoPath(tc.gitSync)
+			assert.Nil(t, err)
+			err = os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{
 				URL: tc.gitSync.Spec.RepoUrl,
@@ -341,8 +342,9 @@ func Test_GetLatestManifests(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
-			localRepoPath := getLocalRepoPath(tc.gitSync)
-			err := os.RemoveAll(localRepoPath)
+			localRepoPath, err := getLocalRepoPath(tc.gitSync)
+			assert.Nil(t, err)
+			err = os.RemoveAll(localRepoPath)
 			assert.Nil(t, err)
 			cloneOptions := &git.CloneOptions{
 				URL: tc.gitSync.Spec.RepoUrl,
@@ -453,7 +455,7 @@ AAAECl1AymWUHNdRiOu2r2dg97arF3S32bE5zcPTqynwyw50HAtto0bVGTAUATJhiDTjKa
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitClone")
 	assert.NoError(t, err)
@@ -484,7 +486,7 @@ func TestGitCloneRepoSshLocalGitServerFileCredential(t *testing.T) {
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitClone")
 	assert.NoError(t, err)
@@ -526,7 +528,7 @@ func TestGitCloneRepoHTTPLocalGitServer(t *testing.T) {
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitCloned")
 	assert.NoError(t, err)
@@ -572,7 +574,7 @@ func TestGitCloneRepoHTTPSLocalGitServer(t *testing.T) {
 	repo, err := cloneRepo(context.Background(), gitSync, cloneOptions, metric)
 	assert.NoError(t, err)
 	assert.NotNil(t, repo)
-	err = FileExists(repo, "data.yaml") // data.yaml default file exists in docker git
+	err = FileExists(repo, "readme.md") // data.yaml default file exists in docker git
 	assert.NoError(t, err)
 	err = os.RemoveAll("gitCloned")
 	assert.NoError(t, err)

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -1,6 +1,7 @@
 clusterName: "staging-usw2-k8s"
 syncTimeIntervalMs: 30000
 cascadeDeletion: false
+persistentRepoClonePath: "/tmp"
 includedResources: "group=apps,kind=Deployment;\
 group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
 group=numaflow.numaproj.io,kind=;\

--- a/tests/config/testconfig2.yaml
+++ b/tests/config/testconfig2.yaml
@@ -1,3 +1,4 @@
 clusterName: "staging-usw2-k8s"
 syncTimeIntervalMs: 30000
 cascadeDeletion: false
+persistentRepoClonePath: "/tmp"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Yes

Fixes https://github.com/numaproj-labs/numaplane/issues/88

### Modifications

Added a persistent volume and persistent volume claim to the GitSync controller to map the path with the cluster node path or host path. Additionally, modified the git clone process to utilize this persistent volume claim path for cloning repositories.

### Verification

The code has been tested in a local Kind cluster, where the cloned repository is visible in the cluster node's host path. Since the Kind cluster runs inside a Docker container, executing the `docker exec -it` command with shell access allows entry into the host path specified in the PV YAML file.

