### PR TITLE
feat: replacing GitSync annotation with label

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,8 +1,8 @@
 package common
 
 const (
-	// AnnotationKeyGitSyncInstance Resource metadata annotations (keys and values) used for tracking
-	AnnotationKeyGitSyncInstance = "numaplane.numaproj.io/tracking-id"
+	// LabelKeyGitSyncInstance Resource metadata labels (keys and values) used for tracking
+	LabelKeyGitSyncInstance = "numaplane.numaproj.io/tracking-id"
 	// SSAManager is the default numaplane manager name used by server-side apply syncs
 	SSAManager = "numaplane-controller"
 	// EnvLogLevel log level that is defined by `--loglevel` option

--- a/internal/sync/cache.go
+++ b/internal/sync/cache.go
@@ -234,9 +234,9 @@ func (c *liveStateCache) PopulateResourceInfo(un *unstructured.Unstructured, isR
 	return res, res.GitSyncName != "" || gvk.Kind == kube.CustomResourceDefinitionKind
 }
 
-// getGitSyncName gets the GitSync that owns the resource from an annotation in the resource
+// getGitSyncName gets the GitSync that owns the resource from a label in the resource
 func getGitSyncName(un *unstructured.Unstructured) string {
-	value, err := kubernetes.GetGitSyncInstanceAnnotation(un, common.AnnotationKeyGitSyncInstance)
+	value, err := kubernetes.GetGitSyncInstanceLabel(un, common.LabelKeyGitSyncInstance)
 	if err != nil {
 		return ""
 	}

--- a/internal/sync/cache_test.go
+++ b/internal/sync/cache_test.go
@@ -167,7 +167,7 @@ func testDeploy() *appsv1.Deployment {
 			UID:               "3",
 			ResourceVersion:   "123",
 			CreationTimestamp: metav1.NewTime(testCreationTime),
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				"numaplane.numaproj.io/tracking-id": testGitSyncName,
 			},
 		},
@@ -190,7 +190,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-app
-  annotations:
+  labels:
     numaplane.numaproj.io/tracking-id: my-gitsync`)
 
 	managedObjs, err := clusterCache.GetManagedLiveObjs(defaultGitSync, []*unstructured.Unstructured{targetDeploy})

--- a/internal/sync/testdata/pipeline-live.yaml
+++ b/internal/sync/testdata/pipeline-live.yaml
@@ -1,7 +1,7 @@
 apiVersion: numaflow.numaproj.io/v1alpha1
 kind: Pipeline
 metadata:
-  annotations:
+  labels:
     numaplane.numaproj.io/tracking-id: gitsync-example
   creationTimestamp: "2024-03-08T22:09:18Z"
   finalizers:

--- a/internal/util/kubernetes/kubernetes.go
+++ b/internal/util/kubernetes/kubernetes.go
@@ -30,30 +30,31 @@ func IsValidKubernetesNamespace(name string) bool {
 	return false
 }
 
-// GetGitSyncInstanceAnnotation returns the application instance name from annotation
-func GetGitSyncInstanceAnnotation(un *unstructured.Unstructured, key string) (string, error) {
-	annotations, err := nestedNullableStringMap(un.Object, "metadata", "annotations")
+// GetGitSyncInstanceLabel returns the application instance name from annotation
+func GetGitSyncInstanceLabel(un *unstructured.Unstructured, key string) (string, error) {
+	labels, err := nestedNullableStringMap(un.Object, "metadata", "labels")
 	if err != nil {
-		return "", fmt.Errorf("failed to get annotations from target object %s %s/%s: %w", un.GroupVersionKind().String(), un.GetNamespace(), un.GetName(), err)
+		return "", fmt.Errorf("failed to get labels from target object %s %s/%s: %w", un.GroupVersionKind().String(), un.GetNamespace(), un.GetName(), err)
 	}
-	if annotations != nil {
-		return annotations[key], nil
+	if labels != nil {
+		return labels[key], nil
 	}
 	return "", nil
 }
 
-// SetGitSyncInstanceAnnotation sets the recommended app.kubernetes.io/instance annotation against an unstructured object
-func SetGitSyncInstanceAnnotation(target *unstructured.Unstructured, key, val string) error {
-	annotations, err := nestedNullableStringMap(target.Object, "metadata", "annotations")
-	if err != nil {
-		return fmt.Errorf("failed to get annotations from target object %s %s/%s: %w", target.GroupVersionKind().String(), target.GetNamespace(), target.GetName(), err)
-	}
+// SetGitSyncInstanceLabel sets the recommended app.kubernetes.io/instance label against an unstructured object
+func SetGitSyncInstanceLabel(target *unstructured.Unstructured, key, val string) error {
 
-	if annotations == nil {
-		annotations = make(map[string]string)
+	labels, err := nestedNullableStringMap(target.Object, "metadata", "labels")
+	if err != nil {
+		return fmt.Errorf("failed to get labels from target object %s %s/%s: %w", target.GroupVersionKind().String(), target.GetNamespace(), target.GetName(), err)
 	}
-	annotations[key] = val
-	target.SetAnnotations(annotations)
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[key] = val
+	target.SetLabels(labels)
+
 	return nil
 }
 

--- a/internal/util/kubernetes/kubernetes.go
+++ b/internal/util/kubernetes/kubernetes.go
@@ -30,7 +30,7 @@ func IsValidKubernetesNamespace(name string) bool {
 	return false
 }
 
-// GetGitSyncInstanceLabel returns the application instance name from annotation
+// GetGitSyncInstanceLabel returns the application instance name from label
 func GetGitSyncInstanceLabel(un *unstructured.Unstructured, key string) (string, error) {
 	labels, err := nestedNullableStringMap(un.Object, "metadata", "labels")
 	if err != nil {

--- a/internal/util/kubernetes/kubernetes_test.go
+++ b/internal/util/kubernetes/kubernetes_test.go
@@ -50,30 +50,30 @@ func TestIsValidKubernetesNamespace(t *testing.T) {
 	}
 }
 
-func TestGetGitSyncInstanceAnnotation(t *testing.T) {
+func TestGetGitSyncInstanceLabel(t *testing.T) {
 	yamlBytes, err := os.ReadFile("testdata/svc.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
-	err = SetGitSyncInstanceAnnotation(&obj, common.AnnotationKeyGitSyncInstance, "my-gitsync")
+	err = SetGitSyncInstanceLabel(&obj, common.LabelKeyGitSyncInstance, "my-gitsync")
 	assert.Nil(t, err)
 
-	annotation, err := GetGitSyncInstanceAnnotation(&obj, common.AnnotationKeyGitSyncInstance)
+	label, err := GetGitSyncInstanceLabel(&obj, common.LabelKeyGitSyncInstance)
 	assert.Nil(t, err)
-	assert.Equal(t, "my-gitsync", annotation)
+	assert.Equal(t, "my-gitsync", label)
 }
 
-func TestGetGitSyncInstanceAnnotationWithInvalidData(t *testing.T) {
+func TestGetGitSyncInstanceLabelWithInvalidData(t *testing.T) {
 	yamlBytes, err := os.ReadFile("testdata/svc-with-invalid-data.yaml")
 	assert.Nil(t, err)
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
 
-	_, err = GetGitSyncInstanceAnnotation(&obj, "valid-annotation")
+	_, err = GetGitSyncInstanceLabel(&obj, "valid-label")
 	assert.Error(t, err)
-	assert.Equal(t, "failed to get annotations from target object /v1, Kind=Service /my-service: .metadata.annotations accessor error: contains non-string key in the map: <nil> is of the type <nil>, expected string", err.Error())
+	assert.Equal(t, "failed to get labels from target object /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string key in the map: <nil> is of the type <nil>, expected string", err.Error())
 }
 
 func TestGetSecret(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #214 

### Modifications

GitSync resources currently get an annotation added: `numaplane.numaproj.io/tracking-id: gitsync-example`
This PR converts this annotation to a label instead. This will allow for the use of a label selector in the future to select resources by GitSync.


### Verification

Created example GitSyncs and checked that created resources had correct label and didn't have previous annotation.

