### PR TITLE
fix: typo in cache filter config

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -429,7 +429,7 @@ data:
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;\
     group=numaflow.numaproj.io,kind=;\
-    group=numaflow.numaproj.io,kind=;\
+    group=numaplane.numaproj.io,kind=;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 kind: ConfigMap
 metadata:

--- a/config/manager/controller-config.yaml
+++ b/config/manager/controller-config.yaml
@@ -9,5 +9,5 @@ data:
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;\
     group=numaflow.numaproj.io,kind=;\
-    group=numaflow.numaproj.io,kind=;\
+    group=numaplane.numaproj.io,kind=;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -38,7 +38,7 @@ func TestLoadConfigMatchValues(t *testing.T) {
 	assert.Equal(t, "group=apps,kind=Deployment;"+
 		"group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;"+
 		"group=numaflow.numaproj.io,kind=;"+
-		"group=numaflow.numaproj.io,kind=;"+
+		"group=numaplane.numaproj.io,kind=;"+
 		"group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role",
 		config.IncludedResources, "IncludedResources does not match")
 

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -5,7 +5,7 @@ persistentRepoClonePath: "/tmp"
 includedResources: "group=apps,kind=Deployment;\
 group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
 group=numaflow.numaproj.io,kind=;\
-group=numaflow.numaproj.io,kind=;\
+group=numaplane.numaproj.io,kind=;\
 group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 repoCredentials:
   - url: "github.com/numaproj-labs"

--- a/tests/e2e/manifests/config.yaml
+++ b/tests/e2e/manifests/config.yaml
@@ -5,7 +5,7 @@ cascadeDeletion: false
 includedResources: "group=apps,kind=Deployment;\
 group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
 group=numaflow.numaproj.io,kind=;\
-group=numaflow.numaproj.io,kind=;\
+group=numaplane.numaproj.io,kind=;\
 group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 repoCredentials:
 - url: "localgitserver-service.numaplane-system.svc.cluster.local/git"

--- a/tests/e2e/manifests/from-json-config.yaml
+++ b/tests/e2e/manifests/from-json-config.yaml
@@ -5,7 +5,7 @@ cascadeDeletion: false
 includedResources: "group=apps,kind=Deployment;\
 group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
 group=numaflow.numaproj.io,kind=;\
-group=numaflow.numaproj.io,kind=;\
+group=numaplane.numaproj.io,kind=;\
 group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 repoCredentials:
 - url: "localgitserver-service.numaplane-system.svc.cluster.local/git"

--- a/tests/e2e/manifests/from-yaml-config.yaml
+++ b/tests/e2e/manifests/from-yaml-config.yaml
@@ -5,7 +5,7 @@ cascadeDeletion: false
 includedResources: "group=apps,kind=Deployment;\
 group=,kind=ConfigMap;group=,kind=Secret;group=,kind=ServiceAccount;group=,kind=Namespace;\
 group=numaflow.numaproj.io,kind=;\
-group=numaflow.numaproj.io,kind=;\
+group=numaplane.numaproj.io,kind=;\
 group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 repoCredentials:
 - url: "localgitserver-service.numaplane-system.svc.cluster.local/git"

--- a/tests/manifests/config.yaml
+++ b/tests/manifests/config.yaml
@@ -4,7 +4,7 @@ cascadeDeletion: false
 includedResources: "group=apps,kind=Deployment;\
 group=,kind=ConfigMap;group=,kind=ServiceAccount;\
 group=numaflow.numaproj.io,kind=;\
-group=numaflow.numaproj.io,kind=;\
+group=numaplane.numaproj.io,kind=;\
 group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 repoCredentials:
 - url: "github.com/numaproj-labs"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications
Fixes cache filter config to correctly include `numaplane.numaproj.io`.


### Verification

e2e Test

