### PR TITLE
fix: panics in controller-runtime

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -78,6 +79,7 @@ func main() {
 
 	numaLogger.SetLevel(config.LogLevel)
 	logger.SetBaseLogger(numaLogger)
+	clog.SetLogger(*numaLogger.LogrLogger)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fix panics caused when updating controller-runtime [here](https://github.com/numaproj-labs/numaplane/pull/308/files).

Panics like this:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
       >  goroutine 143 [running]:
       >  runtime/debug.Stack()
       >      /usr/local/go/src/runtime/debug/stack.go:24 +0x64
       >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
       >      /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/log/log.go:60 +0xf4
       >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Error(0x4000186500, {0x25ff980, 0x40006af480}, {0x211654c, 0x3d}, {0x40003be880, 0x2, 0x2})
       >      /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/log/deleg.go:139 +0x44
       >  github.com/go-logr/logr.Logger.Error({{0x2626f08?, 0x4000186500?}, 0x1ba0d40?}, {0x25ff980, 0x40006af480}, {0x211654c, 0x3d}, {0x40003be880, 0x2, 0x2})
       >      /go/pkg/mod/github.com/go-logr/logr@v1.4.1/logr.go:301 +0xb4
       >  sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1({0x2621c98?, 0x400048c370?})
       >      /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:63 +0x25c
       >  k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2(0x400073bde0?, {0x2621c98?, 0x400048c370?})
       >      /go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:87 +0x58
       >  k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext({0x2621c98, 0x400048c370}, {0x261c0f0?, 0x40003f6e80}, 0x1, 0x0, 0x0?)
       >      /go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/loop.go:88 +0x1ac
       >  k8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel({0x2621c98, 0x400048c370}, 0x23e41?, 0x0?, 0x0?)
       >      /go/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/poll.go:33 +0x74
       >  sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1()
       >      /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:56 +0xb8
       >  created by sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start in goroutine 138
       >      /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/source/kind.go:48 +0x1c4
```

Verified by running image 

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

