### PR TITLE
Pipeline Controller and ISBService Controller reconciliation logic

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml
@@ -1,8 +1,8 @@
 apiVersion: numaplane.numaproj.io/v1alpha1
 kind: ISBServiceRollout
 metadata:
-  name: isbservicerollout-sample
-  namespace: numaplane-system
+  name: my-isbsvc
+  namespace: example-namespace
 spec:
   interStepBufferService:
     # Example from https://github.com/numaproj/numaflow/blob/main/examples/0-isbsvc-jetstream.yaml

--- a/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
@@ -1,8 +1,8 @@
 apiVersion: numaplane.numaproj.io/v1alpha1
 kind: NumaflowControllerRollout
 metadata:
-  name: numaflowcontrollerrollout-sample
-  namespace: numaplane-system
+  name: my-numaflow-controller
+  namespace: example-namespace
 spec:
   controller:
     version: 1.2.1

--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -1,9 +1,10 @@
 apiVersion: numaplane.numaproj.io/v1alpha1
 kind: PipelineRollout
 metadata:
-  name: pipelinerollout-example
-  namespace: numaplane-system
+  name: my-pipeline
+  namespace: example-namespace
 spec:
+  interStepBufferServiceName: my-isbsvc
   pipeline:
     vertices:
       - name: in

--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -4,8 +4,8 @@ metadata:
   name: my-pipeline
   namespace: example-namespace
 spec:
-  interStepBufferServiceName: my-isbsvc
   pipeline:
+    interStepBufferServiceName: my-isbsvc
     vertices:
       - name: in
         source:

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -86,13 +86,14 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			APIVersion: "numaflow.numaproj.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      isbServiceRollout.Name,
-			Namespace: isbServiceRollout.Namespace,
+			Name:            isbServiceRollout.Name,
+			Namespace:       isbServiceRollout.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(isbServiceRollout.GetObjectMeta(), apiv1.ISBServiceRolloutGroupVersionKind)},
 		},
 		Spec: isbServiceRollout.Spec.InterStepBufferService,
 	}
 
-	err := kubernetes.UpdateCRSpec(ctx, r.restConfig, &obj, "interstepbufferservices")
+	err := kubernetes.ApplyCRSpec(ctx, r.restConfig, &obj, "interstepbufferservices")
 	if err != nil {
 		numaLogger.Errorf(err, "failed to apply CR: %v", err)
 		return ctrl.Result{}, err

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -120,7 +120,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	numaLogger := logger.FromContext(ctx)
 
 	// is isbServiceRollout being deleted? need to remove the finalizer so it can
-	// (OwnerReference will delete the underlying Pipeline through Cascading deletion)
+	// (OwnerReference will delete the underlying ISBService through Cascading deletion)
 	if !isbServiceRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting ISBServiceRollout")
 		if controllerutil.ContainsFinalizer(isbServiceRollout, finalizerName) {

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -19,12 +19,14 @@ package controller
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/numaproj-labs/numaplane/internal/kubernetes"
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
@@ -80,6 +82,59 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
+	// save off a copy of the original before we modify it
+	isbServiceRolloutOrig := isbServiceRollout
+	isbServiceRollout = isbServiceRolloutOrig.DeepCopy()
+
+	err := r.reconcile(ctx, isbServiceRollout)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update the Spec if needed
+	if r.needsUpdate(isbServiceRolloutOrig, isbServiceRollout) {
+		isbServiceRolloutStatus := isbServiceRollout.Status
+		if err := r.client.Update(ctx, isbServiceRollout); err != nil {
+			numaLogger.Error(err, "Error Updating ISBServiceRollout", "ISBServiceRollout", isbServiceRollout)
+			return ctrl.Result{}, err
+		}
+		// restore the original status, which would've been wiped in the previous call to Update()
+		isbServiceRollout.Status = isbServiceRolloutStatus
+	}
+
+	// Update the Status subresource
+	if isbServiceRollout.DeletionTimestamp.IsZero() { // would've already been deleted
+		if err := r.client.Status().Update(ctx, isbServiceRollout); err != nil {
+			numaLogger.Error(err, "Error Updating isbServiceRollout Status", "isbServiceRollout", isbServiceRollout)
+			return ctrl.Result{}, err
+		}
+	}
+
+	numaLogger.Debug("reconciliation successful")
+
+	return ctrl.Result{}, nil
+}
+
+// reconcile does the real logic
+func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout) error {
+	numaLogger := logger.FromContext(ctx)
+
+	// is isbServiceRollout being deleted? need to remove the finalizer so it can
+	// (OwnerReference will delete the underlying Pipeline through Cascading deletion)
+	if !isbServiceRollout.DeletionTimestamp.IsZero() {
+		numaLogger.Info("Deleting ISBServiceRollout")
+		if controllerutil.ContainsFinalizer(isbServiceRollout, finalizerName) {
+			controllerutil.RemoveFinalizer(isbServiceRollout, finalizerName)
+		}
+		return nil
+	}
+
+	// add Finalizer so we can ensure that we take appropriate action when CRD is deleted
+	if !controllerutil.ContainsFinalizer(isbServiceRollout, finalizerName) {
+		controllerutil.AddFinalizer(isbServiceRollout, finalizerName)
+	}
+
+	// apply ISBService
 	obj := kubernetes.GenericObject{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "InterStepBufferService",
@@ -96,10 +151,26 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	err := kubernetes.ApplyCRSpec(ctx, r.restConfig, &obj, "interstepbufferservices")
 	if err != nil {
 		numaLogger.Errorf(err, "failed to apply CR: %v", err)
-		return ctrl.Result{}, err
+		//todo: isbServiceRollout.Status.MarkFailed("???", err.Error())
+		return err
 	}
 
-	return ctrl.Result{}, nil
+	//todo: isbServiceRollout.Status.MarkRunning() // should already be but just in case
+	return nil
+
+}
+
+func (r *ISBServiceRolloutReconciler) needsUpdate(old, new *apiv1.ISBServiceRollout) bool {
+
+	if old == nil {
+		return true
+	}
+	// check for any fields we might update in the Spec - generally we'd only update a Finalizer or maybe something in the metadata
+	// TODO: we would need to update this if we ever add anything else, like a label or annotation - unless there's a generic check that makes sense
+	if !equality.Semantic.DeepEqual(old.Finalizers, new.Finalizers) {
+		return true
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -19,11 +19,13 @@ package controller
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/numaproj-labs/numaplane/internal/kubernetes"
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
@@ -67,9 +69,12 @@ func (r *PipelineRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// update the Base Logger's level according to the Numaplane Config
 	logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("reconciler").WithValues("pipelinerollout", req.NamespacedName)
+	// update the context with this Logger so downstream users can incorporate these values in the logs
+	ctx = logger.WithLogger(ctx, numaLogger)
 
 	numaLogger.Info("PipelineRollout Reconcile")
 
+	// Get PipelineRollout CR
 	pipelineRollout := &apiv1.PipelineRollout{}
 	if err := r.client.Get(ctx, req.NamespacedName, pipelineRollout); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -80,25 +85,94 @@ func (r *PipelineRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	// save off a copy of the original before we modify it
+	pipelineRolloutOrig := pipelineRollout
+	pipelineRollout = pipelineRolloutOrig.DeepCopy()
+
+	err := r.reconcile(ctx, pipelineRollout)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update the Spec if needed
+	if r.needsUpdate(pipelineRolloutOrig, pipelineRollout) {
+		pipelineRolloutStatus := pipelineRollout.Status
+		if err := r.client.Update(ctx, pipelineRollout); err != nil {
+			numaLogger.Error(err, "Error Updating PipelineRollout", "PipelineRollout", pipelineRollout)
+			return ctrl.Result{}, err
+		}
+		// restore the original status, which would've been wiped in the previous call to Update()
+		pipelineRollout.Status = pipelineRolloutStatus
+	}
+
+	// Update the Status subresource
+	if pipelineRollout.DeletionTimestamp.IsZero() { // would've already been deleted
+		if err := r.client.Status().Update(ctx, pipelineRollout); err != nil {
+			numaLogger.Error(err, "Error Updating PipelineRollout Status", "PipelineRollout", pipelineRollout)
+			return ctrl.Result{}, err
+		}
+	}
+
+	numaLogger.Debug("reconciliation successful")
+
+	return ctrl.Result{}, nil
+}
+
+// reconcile does the real logic
+func (r *PipelineRolloutReconciler) reconcile(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
+	numaLogger := logger.FromContext(ctx)
+
+	// is PipelineRollout being deleted? need to remove the finalizer so it can
+	// (OwnerReference will delete the underlying Pipeline through Cascading deletion)
+	if !pipelineRollout.DeletionTimestamp.IsZero() {
+		numaLogger.Info("Deleting PipelineRollout")
+		if controllerutil.ContainsFinalizer(pipelineRollout, finalizerName) {
+			controllerutil.RemoveFinalizer(pipelineRollout, finalizerName)
+		}
+		return nil
+	}
+
+	// add Finalizer so we can ensure that we take appropriate action when CRD is deleted
+	if !controllerutil.ContainsFinalizer(pipelineRollout, finalizerName) {
+		controllerutil.AddFinalizer(pipelineRollout, finalizerName)
+	}
+
+	// apply Pipeline
 	obj := kubernetes.GenericObject{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pipeline",
 			APIVersion: "numaflow.numaproj.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pipelineRollout.Name,
-			Namespace: pipelineRollout.Namespace,
+			Name:            pipelineRollout.Name,
+			Namespace:       pipelineRollout.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(pipelineRollout.GetObjectMeta(), apiv1.PipelineRolloutGroupVersionKind)},
 		},
 		Spec: pipelineRollout.Spec.Pipeline,
 	}
 
-	err := kubernetes.UpdateCRSpec(ctx, r.restConfig, &obj, "pipelines")
+	err := kubernetes.ApplyCRSpec(ctx, r.restConfig, &obj, "pipelines")
 	if err != nil {
 		numaLogger.Errorf(err, "failed to apply CR: %v", err)
-		return ctrl.Result{}, err
+		//todo: pipelineRollout.Status.MarkFailed("???", err.Error())
+		return err
 	}
 
-	return ctrl.Result{}, nil
+	//todo: pipelineRollout.Status.MarkRunning() // should already be but just in case
+	return nil
+}
+
+func (r *PipelineRolloutReconciler) needsUpdate(old, new *apiv1.PipelineRollout) bool {
+
+	if old == nil {
+		return true
+	}
+	// check for any fields we might update in the Spec - generally we'd only update a Finalizer or maybe something in the metadata
+	// TODO: we would need to update this if we ever add anything else, like a label or annotation - unless there's a generic check that makes sense
+	if !equality.Semantic.DeepEqual(old.Finalizers, new.Finalizers) {
+		return true
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/kubernetes/dynamic_client.go
+++ b/internal/kubernetes/dynamic_client.go
@@ -40,9 +40,9 @@ type GenericObject struct {
 	Spec runtime.RawExtension `json:"spec"`
 }
 
-// UpdateCRSpec either creates or updates an object identified by the RawExtension, using the new definition,
+// ApplyCRSpec either creates or updates an object identified by the RawExtension, using the new definition,
 // first checking to see if there's a difference in Spec before applying
-func UpdateCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericObject, pluralName string) error {
+func ApplyCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericObject, pluralName string) error {
 	numaLogger := logger.FromContext(ctx)
 
 	// todo: Set the annotation for the hashed spec in the spec

--- a/pkg/apis/numaplane/v1alpha1/groupversion_info.go
+++ b/pkg/apis/numaplane/v1alpha1/groupversion_info.go
@@ -36,6 +36,15 @@ var (
 
 	GitSyncGroupVersionKind     = SchemeGroupVersion.WithKind("GitSync")
 	GitSyncGroupVersionResource = SchemeGroupVersion.WithResource("gitsyncs")
+
+	ISBServiceRolloutGroupVersionKind     = SchemeGroupVersion.WithKind("ISBServiceRollout")
+	ISBServiceRolloutGroupVersionResource = SchemeGroupVersion.WithResource("isbservicerollouts")
+
+	PipelineRolloutGroupVersionKind     = SchemeGroupVersion.WithKind("PipelineRollout")
+	PipelineRolloutGroupVersionResource = SchemeGroupVersion.WithResource("pipelinerollouts")
+
+	NumaflowControllerRolloutGroupVersionKind     = SchemeGroupVersion.WithKind("NumaflowControllerRollout")
+	NumaflowControllerRolloutGroupVersionResource = SchemeGroupVersion.WithResource("numaflowcontrollerrollouts")
 )
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

This includes all of the reconciliation logic, with exception to the Status functions that Tony is working on (there are "todo" placeholders for those).

Tested by doing the following for both PipelineRollout and ISBServiceRollout:
- created Rollout object from our `samples` directory
- verified finalizer added to it
- verified ownerreference added to child object
- updated Rollout object spec (observed that child object changed, or in the case of ISBService, the numflow webhook denied the change as not allowed)
- deleted Rollout object and observed that child object got deleted

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

