### PR TITLE
Apply NumaflowController Spec

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -144,11 +144,16 @@ func main() {
 		numaLogger.Fatal(err, "Unable to set up PipelineRollout controller")
 	}
 
-	numaflowControllerRolloutReconciler := controller.NewNumaflowControllerRolloutReconciler(
+	numaflowControllerRolloutReconciler, err := controller.NewNumaflowControllerRolloutReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetConfig(),
+		metricServer,
+		kubectl,
 	)
+	if err != nil {
+		numaLogger.Fatal(err, "Unable to create NumaflowControllerRollout controller")
+	}
 
 	if err = numaflowControllerRolloutReconciler.SetupWithManager(mgr); err != nil {
 		numaLogger.Fatal(err, "Unable to set up NumaflowControllerRollout controller")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,8 +42,9 @@ var (
 	// scheme is the runtime.Scheme to which all Numaplane API types are registered.
 	scheme = runtime.NewScheme()
 	// logger is the global logger for the controller-manager.
-	numaLogger = logger.New().WithName("controller-manager")
-	configPath = "/etc/numaplane" // Path in the volume mounted in the pod where yaml is present
+	numaLogger    = logger.New().WithName("controller-manager")
+	configPath    = "/etc/numaplane" // Path in the volume mounted in the pod where yaml is present
+	defConfigPath = "/etc/numarollout"
 )
 
 func init() {
@@ -67,7 +68,11 @@ func main() {
 	configManager := config.GetConfigManagerInstance()
 	err := configManager.LoadAllConfigs(func(err error) {
 		numaLogger.Error(err, "Failed to reload global configuration file")
-	}, config.WithConfigsPath(configPath), config.WithConfigFileName("config"))
+	},
+		config.WithConfigsPath(configPath),
+		config.WithConfigFileName("config"),
+		config.WithDefConfigPath(defConfigPath),
+		config.WithDefConfigFileName("controller_definitions"))
 	if err != nil {
 		numaLogger.Fatal(err, "Failed to load config file")
 	}

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1074,7 +1074,7 @@ metadata:
   name: numaplane-controller-manager
   namespace: numaplane-system
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: controller-manager
@@ -1121,8 +1121,6 @@ spec:
             - ALL
         volumeMounts:
         - mountPath: /etc/numaplane
-          name: config-volume
-        - mountPath: /etc/numarollout
           name: numarollout-volume
       initContainers: []
       serviceAccountName: numaplane-sa

--- a/config/manager/controller-manager.yaml
+++ b/config/manager/controller-manager.yaml
@@ -12,7 +12,7 @@ spec:
       app.kubernetes.io/name: controller-manager
       app.kubernetes.io/part-of: numaplane
       app.kubernetes.io/component: controller-manager
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       annotations:

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,8 +1,8 @@
 package common
 
 const (
-	// LabelKeyGitSyncInstance Resource metadata labels (keys and values) used for tracking
-	LabelKeyGitSyncInstance = "numaplane.numaproj.io/tracking-id"
+	// LabelKeyNumaplaneInstance Resource metadata labels (keys and values) used for tracking
+	LabelKeyNumaplaneInstance = "numaplane.numaproj.io/tracking-id"
 	// SSAManager is the default numaplane manager name used by server-side apply syncs
 	SSAManager = "numaplane-controller"
 	// EnvLogLevel log level that is defined by `--loglevel` option

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -63,7 +63,7 @@ func (cm *ConfigManager) GetConfig() (GlobalConfig, error) {
 	return *config, nil
 }
 
-func (cm *ConfigManager) GetNumaRolloutConfig() (NumaflowControllerDefinitionConfig, error) {
+func (cm *ConfigManager) GetControllerDefinitionsConfig() (NumaflowControllerDefinitionConfig, error) {
 	cm.lock.RLock()
 	defer cm.lock.RUnlock()
 
@@ -80,13 +80,21 @@ func (cm *ConfigManager) LoadAllConfigs(
 ) error {
 	opts := defaultOptions()
 	for _, o := range options {
-		o(opts)
+		if o != nil {
+			o(opts)
+		}
 	}
 	if opts.configFileName != "" {
-		cm.loadConfig(onErrorReloading, opts.configsPath, opts.configFileName, opts.configFileType, false)
+		err := cm.loadConfig(onErrorReloading, opts.configsPath, opts.configFileName, opts.configFileType, false)
+		if err != nil {
+			return err
+		}
 	}
 	if opts.rolloutConfigFileName != "" {
-		cm.loadConfig(onErrorReloading, opts.configsPath, opts.rolloutConfigFileName, opts.configFileType, true)
+		err := cm.loadConfig(onErrorReloading, opts.configsPath, opts.rolloutConfigFileName, opts.configFileType, true)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -85,13 +85,13 @@ func (cm *ConfigManager) LoadAllConfigs(
 		}
 	}
 	if opts.configFileName != "" {
-		err := cm.loadConfig(onErrorReloading, opts.configsPath, opts.configFileName, opts.configFileType, false)
+		err := cm.loadConfig(onErrorReloading, opts.configsPath, opts.configFileName, opts.fileType, false)
 		if err != nil {
 			return err
 		}
 	}
-	if opts.rolloutConfigFileName != "" {
-		err := cm.loadConfig(onErrorReloading, opts.configsPath, opts.rolloutConfigFileName, opts.configFileType, true)
+	if opts.defConfigFileName != "" {
+		err := cm.loadConfig(onErrorReloading, opts.defConfigPath, opts.defConfigFileName, opts.fileType, true)
 		if err != nil {
 			return err
 		}

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -96,7 +96,7 @@ func TestLoadNumaRolloutConfigMatchValues(t *testing.T) {
 	configManager := GetConfigManagerInstance()
 	err = configManager.LoadAllConfigs(func(err error) {}, WithConfigsPath(configPath), WithRolloutConfigFileName("controller-definitions-config"))
 	assert.NoError(t, err)
-	config, err := configManager.GetNumaRolloutConfig()
+	config, err := configManager.GetControllerDefinitionsConfig()
 	assert.NoError(t, err)
 
 	assert.Nil(t, err, "Failed to load configuration")

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -94,7 +94,7 @@ func TestLoadNumaRolloutConfigMatchValues(t *testing.T) {
 	assert.Nil(t, err, "Failed to get working directory")
 	configPath := filepath.Join(getwd, "../../../", "tests", "config")
 	configManager := GetConfigManagerInstance()
-	err = configManager.LoadAllConfigs(func(err error) {}, WithConfigsPath(configPath), WithRolloutConfigFileName("controller-definitions-config"))
+	err = configManager.LoadAllConfigs(func(err error) {}, WithDefConfigPath(configPath), WithDefConfigFileName("controller-definitions-config"))
 	assert.NoError(t, err)
 	config, err := configManager.GetControllerDefinitionsConfig()
 	assert.NoError(t, err)
@@ -104,7 +104,7 @@ func TestLoadNumaRolloutConfigMatchValues(t *testing.T) {
 	assert.NotNil(t, config.ControllerDefinitions, "ControllerDefinitions should not be nil")
 
 	assert.Equal(t, "1.2.1", config.ControllerDefinitions[0].Version, "Version for ControllerDefinitions[0] does not match")
-	assert.Equal(t, "", config.ControllerDefinitions[0].FullSpec, "FullSpec for ControllerDefinitions[0] does not match")
+	assert.Equal(t, "apiVersion: apps/v1\nkind: Deployment\n", config.ControllerDefinitions[0].FullSpec, "FullSpec for ControllerDefinitions[0] does not match")
 	assert.Equal(t, "1.1.7", config.ControllerDefinitions[1].Version, "Version for ControllerDefinitions[1] does not match")
 	assert.Equal(t, "", config.ControllerDefinitions[1].FullSpec, "FullSpec for ControllerDefinitions[1] does not match")
 }

--- a/internal/controller/config/options.go
+++ b/internal/controller/config/options.go
@@ -1,17 +1,18 @@
 package config
 
 type options struct {
-	configsPath           string
-	configFileName        string
-	configFileType        string
-	rolloutConfigFileName string
+	configsPath       string
+	configFileName    string
+	defConfigFileName string
+	defConfigPath     string
+	fileType          string
 }
 
 type Option func(*options)
 
 func defaultOptions() *options {
 	return &options{
-		configFileType: "yaml",
+		fileType: "yaml",
 	}
 }
 
@@ -27,14 +28,14 @@ func WithConfigFileName(configFileName string) Option {
 	}
 }
 
-func WithConfigFileType(configFileType string) Option {
+func WithDefConfigPath(defConfigPath string) Option {
 	return func(o *options) {
-		o.configFileType = configFileType
+		o.defConfigPath = defConfigPath
 	}
 }
 
-func WithRolloutConfigFileName(rolloutConfigFileName string) Option {
+func WithDefConfigFileName(defConfigFileName string) Option {
 	return func(o *options) {
-		o.rolloutConfigFileName = rolloutConfigFileName
+		o.defConfigFileName = defConfigFileName
 	}
 }

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -18,7 +18,11 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
+	gitopsSync "github.com/argoproj/gitops-engine/pkg/sync"
+	gitopsSyncCommon "github.com/argoproj/gitops-engine/pkg/sync/common"
+	kubeUtil "github.com/argoproj/gitops-engine/pkg/utils/kube"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -26,6 +30,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/argoproj/gitops-engine/pkg/diff"
+	"github.com/numaproj-labs/numaplane/internal/common"
+	"github.com/numaproj-labs/numaplane/internal/controller/config"
+	"github.com/numaproj-labs/numaplane/internal/metrics"
+	"github.com/numaproj-labs/numaplane/internal/sync"
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj-labs/numaplane/pkg/apis/numaplane/v1alpha1"
 )
@@ -35,18 +44,59 @@ type NumaflowControllerRolloutReconciler struct {
 	client     client.Client
 	scheme     *runtime.Scheme
 	restConfig *rest.Config
+	rawConfig  *rest.Config
+	kubectl    kubeUtil.Kubectl
+
+	definitions map[string]string
+	stateCache  sync.LiveStateCache
 }
 
 func NewNumaflowControllerRolloutReconciler(
 	client client.Client,
 	s *runtime.Scheme,
-	restConfig *rest.Config,
-) *NumaflowControllerRolloutReconciler {
+	rawConfig *rest.Config,
+	metricServer *metrics.MetricsServer,
+	kubectl kubeUtil.Kubectl,
+) (*NumaflowControllerRolloutReconciler, error) {
+	stateCache := sync.NewLiveStateCache(rawConfig)
+	logger.RefreshBaseLoggerLevel()
+	numaLogger := logger.GetBaseLogger().WithName("state cache").WithValues("numaflowcontrollerrollout")
+	err := stateCache.Init(numaLogger)
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig := metrics.AddMetricsTransportWrapper(metricServer, rawConfig)
+	definitions, err := loadDefinitions()
+	if err != nil {
+		return nil, err
+	}
 	return &NumaflowControllerRolloutReconciler{
 		client,
 		s,
 		restConfig,
+		rawConfig,
+		kubectl,
+		definitions,
+		stateCache,
+	}, nil
+}
+
+func loadDefinitions() (map[string]string, error) {
+	definitionsConfig, err := config.GetConfigManagerInstance().GetControllerDefinitionsConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the controller definitions config, %v", err)
 	}
+
+	logger.RefreshBaseLoggerLevel()
+	numaLogger := logger.GetBaseLogger().WithName("loadDefinitions").WithValues("numaflowcontrollerrollout_1")
+
+	definitions := make(map[string]string)
+	for _, definition := range definitionsConfig.ControllerDefinitions {
+		definitions[definition.Version] = definition.FullSpec
+		numaLogger.Info("def", "version", definition.Version, "spec", definition.FullSpec)
+	}
+	return definitions, nil
 }
 
 //+kubebuilder:rbac:groups=numaplane.numaproj.io,resources=numaflowcontrollerrollouts,verbs=get;list;watch;create;update;patch;delete
@@ -78,8 +128,122 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// TODO: reconciliation logic here
+	_, _ = r.sync(numaflowControllerRollout, req.Namespace, "", numaLogger)
 
 	return ctrl.Result{}, nil
+}
+
+// TODO: share sync logic with `syncer`
+func (r *NumaflowControllerRolloutReconciler) sync(
+	rollout *apiv1.NumaflowControllerRollout,
+	namespace string,
+	revision string,
+	numaLogger *logger.NumaLogger,
+) (gitopsSyncCommon.OperationPhase, string) {
+
+	// Get the target manifests
+	version := rollout.Spec.Controller.Version
+	manifest := r.definitions[version]
+	numaLogger.Info("log manifest: " + manifest)
+	targetObjs, err := kubeUtil.SplitYAML([]byte(manifest))
+	if err != nil {
+		return gitopsSyncCommon.OperationError, err.Error()
+	}
+
+	var infoProvider kubeUtil.ResourceInfoProvider
+	clusterCache, err := r.stateCache.GetClusterCache()
+	infoProvider = clusterCache
+	if err != nil {
+		return gitopsSyncCommon.OperationError, err.Error()
+	}
+	liveObjByKey, err := r.stateCache.GetManagedLiveObjs(rollout.Name, targetObjs)
+	if err != nil {
+		return gitopsSyncCommon.OperationError, err.Error()
+	}
+	reconciliationResult := gitopsSync.Reconcile(targetObjs, liveObjByKey, namespace, infoProvider)
+
+	// Ignore `status` field for all comparison.
+	// TODO: make it configurable
+	overrides := map[string]sync.ResourceOverride{
+		"*/*": {
+			IgnoreDifferences: sync.OverrideIgnoreDiff{JSONPointers: []string{"/status"}}},
+	}
+
+	resourceOps, cleanup, err := r.getResourceOperations()
+	if err != nil {
+		return gitopsSyncCommon.OperationError, err.Error()
+	}
+	defer cleanup()
+
+	diffOpts := []diff.Option{
+		diff.WithLogr(*numaLogger.LogrLogger),
+		diff.WithServerSideDiff(true),
+		diff.WithServerSideDryRunner(diff.NewK8sServerSideDryRunner(resourceOps)),
+		diff.WithManager(common.SSAManager),
+		diff.WithGVKParser(clusterCache.GetGVKParser()),
+	}
+
+	diffResults, err := sync.StateDiffs(reconciliationResult.Target, reconciliationResult.Live, overrides, diffOpts)
+	if err != nil {
+		numaLogger.Error(err, "Error on comparing git sync state")
+		return gitopsSyncCommon.OperationError, err.Error()
+	}
+
+	opts := []gitopsSync.SyncOpt{
+		gitopsSync.WithLogr(*numaLogger.LogrLogger),
+		gitopsSync.WithOperationSettings(false, true, false, false),
+		gitopsSync.WithManifestValidation(true),
+		gitopsSync.WithPruneLast(false),
+		gitopsSync.WithResourceModificationChecker(true, diffResults),
+		gitopsSync.WithReplace(false),
+		gitopsSync.WithServerSideApply(true),
+		gitopsSync.WithServerSideApplyManager(common.SSAManager),
+	}
+
+	cluster, err := r.stateCache.GetClusterCache()
+	if err != nil {
+		numaLogger.Error(err, "Error on getting the cluster cache")
+		//return gitopsSyncCommon.OperationError, err.Error()
+	}
+	openAPISchema := cluster.GetOpenAPISchema()
+
+	syncCtx, cleanup, err := gitopsSync.NewSyncContext(
+		revision,
+		reconciliationResult,
+		r.restConfig,
+		r.rawConfig,
+		r.kubectl,
+		namespace,
+		openAPISchema,
+		opts...,
+	)
+	defer cleanup()
+	if err != nil {
+		numaLogger.Error(err, "Error on creating syncing context")
+		return gitopsSyncCommon.OperationError, err.Error()
+	}
+
+	syncCtx.Sync()
+
+	phase, message, _ := syncCtx.GetState()
+	return phase, message
+}
+
+// getResourceOperations will return the kubectl implementation of the ResourceOperations
+// interface that provides functionality to manage kubernetes resources. Returns a
+// cleanup function that must be called to remove the generated kube config for this
+// server.
+func (r *NumaflowControllerRolloutReconciler) getResourceOperations() (kubeUtil.ResourceOperations, func(), error) {
+	clusterCache, err := r.stateCache.GetClusterCache()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting cluster cache: %w", err)
+	}
+
+	ops, cleanup, err := r.kubectl.ManageResources(r.restConfig, clusterCache.GetOpenAPISchema())
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating kubectl ResourceOperations: %w", err)
+	}
+	return ops, cleanup, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/sync/cache.go
+++ b/internal/sync/cache.go
@@ -429,6 +429,7 @@ func (c *liveStateCache) GetManagedLiveObjs(
 		return nil, fmt.Errorf("failed to get cluster info: %w", err)
 	}
 	return clusterInfo.GetManagedLiveObjs(targetObjs, func(r *clustercache.Resource) bool {
+		// TODO: distigush between numaplane objects. e.g. NumaflowControllerRollout v.s. GitSync
 		return resInfo(r).Name == name
 	})
 }

--- a/internal/sync/cache.go
+++ b/internal/sync/cache.go
@@ -29,7 +29,6 @@ import (
 	controllerConfig "github.com/numaproj-labs/numaplane/internal/controller/config"
 	"github.com/numaproj-labs/numaplane/internal/util/kubernetes"
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
-	"github.com/numaproj-labs/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
 // GitOps engine cluster cache tuning options
@@ -64,20 +63,20 @@ var (
 )
 
 type ResourceInfo struct {
-	GitSyncName string
+	Name string
 
 	Health       *health.HealthStatus
 	manifestHash string
 }
 
 // LiveStateCache is a cluster caching that stores resource references and ownership
-// references. It also stores custom metadata for resources managed by GitSyncs. It always
+// references. It also stores custom metadata for resources managed by Numaplane. It always
 // ensures the cache is up-to-date before returning the resources.
 type LiveStateCache interface {
 	// GetClusterCache returns synced cluster cache
 	GetClusterCache() (clustercache.ClusterCache, error)
-	// GetManagedLiveObjs returns state of live nodes which correspond to target nodes of specified gitsync.
-	GetManagedLiveObjs(gitsync *v1alpha1.GitSync, targetObjs []*unstructured.Unstructured) (map[kube.ResourceKey]*unstructured.Unstructured, error)
+	// GetManagedLiveObjs returns state of live objects which correspond to target objects with the specified ResourceInfo name.
+	GetManagedLiveObjs(name string, targetObjs []*unstructured.Unstructured) (map[kube.ResourceKey]*unstructured.Unstructured, error)
 	// Init must be executed before cache can be used
 	Init(numaLogger *logger.NumaLogger) error
 	// PopulateResourceInfo is called by the cache to update ResourceInfo struct for a managed resource
@@ -91,7 +90,7 @@ type cacheSettings struct {
 	ignoreResourceUpdatesEnabled bool
 }
 
-type ObjectUpdatedHandler = func(managedByGitSync map[string]bool, ref v1.ObjectReference)
+type ObjectUpdatedHandler = func(managedByNumaplane map[string]bool, ref v1.ObjectReference)
 
 type liveStateCache struct {
 	clusterCacheConfig *rest.Config
@@ -197,7 +196,7 @@ func (c *liveStateCache) getCluster() clustercache.ClusterCache {
 		}
 
 		// TODO: when switch to change event triggering for sync tasking, notify
-		//       the GitSync managing the resources that there are changes happen
+		//       the Numaplane managing the resources that there are changes happen
 	})
 
 	c.cluster = clusterCache
@@ -213,14 +212,14 @@ func (c *liveStateCache) PopulateResourceInfo(un *unstructured.Unstructured, isR
 
 	res.Health, _ = health.GetResourceHealth(un, settings.clusterSettings.ResourceHealthOverride)
 
-	gitSyncName := getGitSyncName(un)
-	if isRoot && gitSyncName != "" {
-		res.GitSyncName = gitSyncName
+	numaplaneInstanceName := getNumaplaneInstanceName(un)
+	if isRoot && numaplaneInstanceName != "" {
+		res.Name = numaplaneInstanceName
 	}
 
 	gvk := un.GroupVersionKind()
 
-	if settings.ignoreResourceUpdatesEnabled && shouldHashManifest(gitSyncName, gvk) {
+	if settings.ignoreResourceUpdatesEnabled && shouldHashManifest(numaplaneInstanceName, gvk) {
 		hash, err := generateManifestHash(un)
 		if err != nil {
 			c.logger.Errorf(err, "failed to generate manifest hash")
@@ -231,12 +230,12 @@ func (c *liveStateCache) PopulateResourceInfo(un *unstructured.Unstructured, isR
 
 	// edge case. we do not label CRDs, so they miss the tracking label we inject. But we still
 	// want the full resource to be available in our cache (to diff), so we store all CRDs
-	return res, res.GitSyncName != "" || gvk.Kind == kube.CustomResourceDefinitionKind
+	return res, res.Name != "" || gvk.Kind == kube.CustomResourceDefinitionKind
 }
 
-// getGitSyncName gets the GitSync that owns the resource from a label in the resource
-func getGitSyncName(un *unstructured.Unstructured) string {
-	value, err := kubernetes.GetGitSyncInstanceLabel(un, common.LabelKeyGitSyncInstance)
+// getNumaplaneInstanceName gets the Numaplane Object that owns the resource from a label in the resource
+func getNumaplaneInstanceName(un *unstructured.Unstructured) string {
+	value, err := kubernetes.GetNumaplaneInstanceLabel(un, common.LabelKeyNumaplaneInstance)
 	if err != nil {
 		return ""
 	}
@@ -252,11 +251,11 @@ func resInfo(r *clustercache.Resource) *ResourceInfo {
 }
 
 // shouldHashManifest validates if the API resource needs to be hashed.
-// If there's a GitSync name from resource tracking, or if this is itself a GitSync, we should generate a hash.
-// Otherwise, the hashing should be skipped to save CPU time.
-func shouldHashManifest(gitSyncName string, gvk schema.GroupVersionKind) bool {
-	// Only hash if the resource belongs to a GitSync.
-	return gitSyncName != "" || (gvk.Group == "numaplane.numaproj.io" && gvk.Kind == "GitSync")
+// If there's a instance name from resource tracking, or if this is itself
+// a Numaplane object, we should generate a hash. Otherwise, the hashing
+// should be skipped to save CPU time.
+func shouldHashManifest(instanceName string, gvk schema.GroupVersionKind) bool {
+	return instanceName != "" || gvk.Group == "numaplane.numaproj.io"
 }
 
 func generateManifestHash(un *unstructured.Unstructured) (string, error) {
@@ -421,13 +420,16 @@ func (c *liveStateCache) GetClusterCache() (clustercache.ClusterCache, error) {
 	return c.getSyncedCluster()
 }
 
-func (c *liveStateCache) GetManagedLiveObjs(gitsync *v1alpha1.GitSync, targetObjs []*unstructured.Unstructured) (map[kube.ResourceKey]*unstructured.Unstructured, error) {
+func (c *liveStateCache) GetManagedLiveObjs(
+	name string,
+	targetObjs []*unstructured.Unstructured,
+) (map[kube.ResourceKey]*unstructured.Unstructured, error) {
 	clusterInfo, err := c.getSyncedCluster()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster info for %q: %w", gitsync.Spec.Destination.Cluster, err)
+		return nil, fmt.Errorf("failed to get cluster info: %w", err)
 	}
 	return clusterInfo.GetManagedLiveObjs(targetObjs, func(r *clustercache.Resource) bool {
-		return resInfo(r).GitSyncName == gitsync.Name
+		return resInfo(r).Name == name
 	})
 }
 

--- a/internal/sync/cache_test.go
+++ b/internal/sync/cache_test.go
@@ -193,7 +193,7 @@ metadata:
   labels:
     numaplane.numaproj.io/tracking-id: my-gitsync`)
 
-	managedObjs, err := clusterCache.GetManagedLiveObjs(defaultGitSync, []*unstructured.Unstructured{targetDeploy})
+	managedObjs, err := clusterCache.GetManagedLiveObjs(defaultGitSync.Name, []*unstructured.Unstructured{targetDeploy})
 	require.NoError(t, err)
 	assert.Equal(t, map[kube.ResourceKey]*unstructured.Unstructured{
 		kube.NewResourceKey("apps", "Deployment", "default", "my-app"): mustToUnstructured(testDeploy()),

--- a/internal/util/kubernetes/kubernetes.go
+++ b/internal/util/kubernetes/kubernetes.go
@@ -30,8 +30,8 @@ func IsValidKubernetesNamespace(name string) bool {
 	return false
 }
 
-// GetGitSyncInstanceLabel returns the application instance name from label
-func GetGitSyncInstanceLabel(un *unstructured.Unstructured, key string) (string, error) {
+// GetNumaplaneInstanceLabel returns the application instance name from label
+func GetNumaplaneInstanceLabel(un *unstructured.Unstructured, key string) (string, error) {
 	labels, err := nestedNullableStringMap(un.Object, "metadata", "labels")
 	if err != nil {
 		return "", fmt.Errorf("failed to get labels from target object %s %s/%s: %w", un.GroupVersionKind().String(), un.GetNamespace(), un.GetName(), err)

--- a/internal/util/kubernetes/kubernetes_test.go
+++ b/internal/util/kubernetes/kubernetes_test.go
@@ -56,10 +56,10 @@ func TestGetGitSyncInstanceLabel(t *testing.T) {
 	var obj unstructured.Unstructured
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
-	err = SetGitSyncInstanceLabel(&obj, common.LabelKeyGitSyncInstance, "my-gitsync")
+	err = SetGitSyncInstanceLabel(&obj, common.LabelKeyNumaplaneInstance, "my-gitsync")
 	assert.Nil(t, err)
 
-	label, err := GetGitSyncInstanceLabel(&obj, common.LabelKeyGitSyncInstance)
+	label, err := GetNumaplaneInstanceLabel(&obj, common.LabelKeyNumaplaneInstance)
 	assert.Nil(t, err)
 	assert.Equal(t, "my-gitsync", label)
 }
@@ -71,7 +71,7 @@ func TestGetGitSyncInstanceLabelWithInvalidData(t *testing.T) {
 	err = yaml.Unmarshal(yamlBytes, &obj)
 	assert.Nil(t, err)
 
-	_, err = GetGitSyncInstanceLabel(&obj, "valid-label")
+	_, err = GetNumaplaneInstanceLabel(&obj, "valid-label")
 	assert.Error(t, err)
 	assert.Equal(t, "failed to get labels from target object /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string", err.Error())
 }

--- a/tests/config/controller-definitions-config.yaml
+++ b/tests/config/controller-definitions-config.yaml
@@ -1,5 +1,10 @@
 controllerDefinitions:
   - version: "1.2.1"
-    fullSpec: ""
+    fullSpec: |
+      apiVersion: apps/v1
+      kind: Deployment
+      ---
+      apiVersion: apps/v1
+      kind: Deployment
   - version: "1.1.7"
     fullSpec: ""

--- a/tests/manifests/controller_definitions.yaml
+++ b/tests/manifests/controller_definitions.yaml
@@ -1,5 +1,5 @@
 controllerDefinitions:
 - version: "1.2.1"
-  fullSpec: ""
+  fullSpec: "apiVersion: apps/v1"
 - version: "1.1.7"
   fullSpec: ""

--- a/tests/manifests/controller_definitions.yaml
+++ b/tests/manifests/controller_definitions.yaml
@@ -1,5 +1,354 @@
 controllerDefinitions:
 - version: "1.2.1"
-  fullSpec: "apiVersion: apps/v1"
+  fullSpec: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: numaflow-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: controller-manager
+          app.kubernetes.io/name: controller-manager
+          app.kubernetes.io/part-of: numaflow
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: controller-manager
+            app.kubernetes.io/name: controller-manager
+            app.kubernetes.io/part-of: numaflow
+        spec:
+          containers:
+            - args:
+                - controller
+              env:
+                - name: NUMAFLOW_IMAGE
+                  value: quay.io/numaproj/numaflow:latest
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: NUMAFLOW_CONTROLLER_NAMESPACED
+                  valueFrom:
+                    configMapKeyRef:
+                      key: namespaced
+                      name: numaflow-cmd-params-config
+                      optional: true
+                - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      key: managed.namespace
+                      name: numaflow-cmd-params-config
+                      optional: true
+                - name: NUMAFLOW_LEADER_ELECTION_DISABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      key: controller.disable.leader.election
+                      name: numaflow-cmd-params-config
+                      optional: true
+              image: quay.io/numaproj/numaflow:latest
+              imagePullPolicy: Always
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8081
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              name: controller-manager
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8081
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 1024Mi
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+              volumeMounts:
+                - mountPath: /etc/numaflow
+                  name: controller-config-volume
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 9737
+          serviceAccountName: numaflow-sa
+          volumes:
+            - configMap:
+                name: numaflow-controller-config
+              name: controller-config-volume
+    ---
+    apiVersion: v1
+    data:
+      controller-config.yaml: |
+        isbsvc:
+          redis:
+            # Default Redis settings, could be overridden by InterStepBufferService specs
+            settings:
+              # Redis config shared by both master and replicas
+              redis: |
+                min-replicas-to-write 1
+                # Disable RDB persistence, AOF persistence already enabled.
+                save ""
+                # Enable AOF https://redis.io/topics/persistence#append-only-file
+                appendonly yes
+                auto-aof-rewrite-percentage 100
+                auto-aof-rewrite-min-size 64mb
+                maxmemory 512mb
+                maxmemory-policy allkeys-lru
+              # Special config only used by master
+              master: ""
+              # Special config only used by replicas
+              replica: ""
+              # Sentinel config
+              sentinel: |
+                sentinel down-after-milliseconds mymaster 10000
+                sentinel failover-timeout mymaster 2000
+                sentinel parallel-syncs mymaster 1
+            versions:
+            - version: 7.0.11
+              redisImage: bitnami/redis:7.0.11-debian-11-r3
+              sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
+              redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+              initContainerImage: debian:latest
+          jetstream:
+            # Default JetStream settings, could be overridden by InterStepBufferService specs
+            settings: |
+              # https://docs.nats.io/running-a-nats-service/configuration#limits
+              # Only support to configure "max_payload".
+              # Max payload size in bytes, defaults to 1 MB. It is not recommended to use values over 8MB but max_payload can be set up to 64MB.
+              max_payload: 1048576
+              # https://docs.nats.io/running-a-nats-service/configuration#jetstream
+              # Only configure "max_memory_store" or "max_file_store", do not set "store_dir" as it has been hardcoded.
+              # e.g. 1G. -1 means no limit, up to 75% of available memory. This only take effect for streams created using memory storage.
+              max_memory_store: -1
+              # e.g. 20G. -1 means no limit, Up to 1TB if available
+              max_file_store: 1TB
+            bufferConfig: |
+              # The default properties of the buffers (streams) to be created in this JetStream service
+              stream:
+                # 0: Limits, 1: Interest, 2: WorkQueue
+                retention: 0
+                maxMsgs: 100000
+                maxAge: 72h
+                maxBytes: -1
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+                duplicates: 60s
+              # The default consumer properties for the created streams
+              consumer:
+                ackWait: 60s
+                maxAckPending: 25000
+              otBucket:
+                maxValueSize: 0
+                history: 1
+                ttl: 3h
+                maxBytes: 0
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+              procBucket:
+                maxValueSize: 0
+                history: 1
+                ttl: 72h
+                maxBytes: 0
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+            versions:
+            - version: latest
+              natsImage: nats:2.10.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.1
+              natsImage: nats:2.8.1
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.1-alpine
+              natsImage: nats:2.8.1-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.8.3
+              natsImage: nats:2.8.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.3-alpine
+              natsImage: nats:2.8.3-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.9.0
+              natsImage: nats:2.9.0
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.0-alpine
+              natsImage: nats:2.9.0-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.9.6
+              natsImage: nats:2.9.6
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.8
+              natsImage: nats:2.9.8
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.15
+              natsImage: nats:2.9.15
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.3
+              natsImage: nats:2.10.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+    kind: ConfigMap
+    metadata:
+      name: numaflow-controller-config
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role
+    rules:
+      - apiGroups:
+          - numaflow.numaproj.io
+        resources:
+          - interstepbufferservices
+          - interstepbufferservices/finalizers
+          - interstepbufferservices/status
+          - pipelines
+          - pipelines/finalizers
+          - pipelines/status
+          - vertices
+          - vertices/finalizers
+          - vertices/status
+          - vertices/scale
+        verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+          - pods/exec
+          - configmaps
+          - services
+          - persistentvolumeclaims
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - statefulsets
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: numaflow-role
+    subjects:
+      - kind: ServiceAccount
+        name: numaflow-sa
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: numaflow-sa
+    ---
+    apiVersion: v1
+    data:
+      namespaced: "true"
+      server.disable.auth: "true"
+    kind: ConfigMap
+    metadata:
+      name: numaflow-cmd-params-config
 - version: "1.1.7"
   fullSpec: ""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

This PR adds the reconciliation logic for NumaflowControllerRollout.


### Verification
Tested in local cluster,

- `make start`
- `kubectl apply -f config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml`

Verified Numaflow Controller successfully deployed to `example-namespace`.


