### PR TITLE
feat: reduce the number of reconciliations

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -27,6 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/numaproj-labs/numaplane/internal/kubernetes"
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
@@ -176,6 +177,7 @@ func (r *ISBServiceRolloutReconciler) needsUpdate(old, new *apiv1.ISBServiceRoll
 // SetupWithManager sets up the controller with the Manager.
 func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&apiv1.ISBServiceRollout{}).
+		// Reconcile ISBServiceRollouts when there's been a Generation changed (i.e. Spec change)
+		For(&apiv1.ISBServiceRollout{}).WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj-labs/numaplane/pkg/apis/numaplane/v1alpha1"
@@ -86,6 +87,7 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 // SetupWithManager sets up the controller with the Manager.
 func (r *NumaflowControllerRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&apiv1.NumaflowControllerRollout{}).
+		// Reconcile NumaflowControllerRollouts when there's been a Generation changed (i.e. Spec change)
+		For(&apiv1.NumaflowControllerRollout{}).WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/numaproj-labs/numaplane/internal/kubernetes"
 	"github.com/numaproj-labs/numaplane/internal/util/logger"
@@ -178,6 +179,7 @@ func (r *PipelineRolloutReconciler) needsUpdate(old, new *apiv1.PipelineRollout)
 // SetupWithManager sets up the controller with the Manager.
 func (r *PipelineRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&apiv1.PipelineRollout{}).
+		// Reconcile PipelineRollouts when there's been a Generation changed (i.e. Spec change)
+		For(&apiv1.PipelineRollout{}).WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

This PR only watches for (and thus calls `Reconcile()` for) Generation changes on the underlying resources - only Spec changes and not other things

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

