### PR TITLE
Print column phase

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_gitsyncs.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_gitsyncs.yaml
@@ -14,7 +14,12 @@ spec:
     singular: gitsync
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: GitSync is the Schema for the gitsyncs API
@@ -206,7 +211,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending

--- a/config/crd/bases/numaplane.numaproj.io_gitsyncs.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_gitsyncs.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase

--- a/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
@@ -14,7 +14,12 @@ spec:
     singular: isbservicerollout
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ISBServiceRollout is the Schema for the isbservicerollouts API
@@ -123,7 +128,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending

--- a/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase

--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -14,7 +14,12 @@ spec:
     singular: numaflowcontrollerrollout
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NumaflowControllerRollout is the Schema for the numaflowcontrollerrollouts
@@ -130,7 +135,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending

--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -14,7 +14,12 @@ spec:
     singular: pipelinerollout
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PipelineRollout is the Schema for the pipelinerollouts API
@@ -123,7 +128,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -14,6 +14,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase
@@ -243,6 +246,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase
@@ -387,6 +393,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase
@@ -538,6 +547,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The current phase
       jsonPath: .status.phase
       name: Phase

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -13,7 +13,12 @@ spec:
     singular: gitsync
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: GitSync is the Schema for the gitsyncs API
@@ -205,7 +210,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending
@@ -237,7 +242,12 @@ spec:
     singular: isbservicerollout
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ISBServiceRollout is the Schema for the isbservicerollouts API
@@ -346,7 +356,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending
@@ -376,7 +386,12 @@ spec:
     singular: numaflowcontrollerrollout
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NumaflowControllerRollout is the Schema for the numaflowcontrollerrollouts
@@ -492,7 +507,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending
@@ -522,7 +537,12 @@ spec:
     singular: pipelinerollout
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PipelineRollout is the Schema for the pipelinerollouts API
@@ -631,7 +651,7 @@ spec:
                 description: Message is added if Phase is PhaseFailed.
                 type: string
               phase:
-                description: Phase indicates the health status.
+                description: Phase indicates the current phase of the resource.
                 enum:
                 - ""
                 - Pending

--- a/pkg/apis/numaplane/v1alpha1/gitsync_types.go
+++ b/pkg/apis/numaplane/v1alpha1/gitsync_types.go
@@ -65,6 +65,8 @@ type CommitStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
+
 // GitSync is the Schema for the gitsyncs API
 type GitSync struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/numaplane/v1alpha1/gitsync_types.go
+++ b/pkg/apis/numaplane/v1alpha1/gitsync_types.go
@@ -65,6 +65,7 @@ type CommitStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 
 // GitSync is the Schema for the gitsyncs API

--- a/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
@@ -36,6 +36,7 @@ type ISBServiceRolloutStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 
 // ISBServiceRollout is the Schema for the isbservicerollouts API

--- a/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
@@ -36,6 +36,7 @@ type ISBServiceRolloutStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 
 // ISBServiceRollout is the Schema for the isbservicerollouts API
 type ISBServiceRollout struct {

--- a/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
@@ -39,6 +39,7 @@ type NumaflowControllerRolloutStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 
 // NumaflowControllerRollout is the Schema for the numaflowcontrollerrollouts API
 type NumaflowControllerRollout struct {

--- a/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
@@ -39,6 +39,7 @@ type NumaflowControllerRolloutStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 
 // NumaflowControllerRollout is the Schema for the numaflowcontrollerrollouts API

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -36,6 +36,7 @@ type PipelineRolloutStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 
 // PipelineRollout is the Schema for the pipelinerollouts API
 type PipelineRollout struct {

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -36,6 +36,7 @@ type PipelineRolloutStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 
 // PipelineRollout is the Schema for the pipelinerollouts API

--- a/pkg/apis/numaplane/v1alpha1/status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/status_types.go
@@ -48,7 +48,7 @@ type Status struct {
 	// +patchStrategy=merge
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
-	// Phase indicates the health status.
+	// Phase indicates the current phase of the resource.
 	Phase Phase `json:"phase,omitempty"`
 
 	// Message is added if Phase is PhaseFailed.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Added columns Phase and Age to the output of the `kubectl get <crd-name>` command.

### Verification

`kubectl -n example-namespace get pipelinerollout`
![image](https://github.com/numaproj-labs/numaplane/assets/161530773/817afa68-308d-473b-be25-04b6c1dd67de)


