### PR TITLE
fix: only `numaflow-controller-definitions-config` should be immutable

### DIFF
--- a/tests/manifests/kustomization.yaml
+++ b/tests/manifests/kustomization.yaml
@@ -24,6 +24,6 @@ configMapGenerator:
   files:
     - controller_definitions.yaml
   behavior: merge  # Optional, defaults to "create"
-generatorOptions:
-  immutable: true
+  options:
+    immutable: true
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->


### Modifications

only `numaflow-controller-definitions-config` should be immutable


### Verification

`kubectl edit configmaps numaplane-controller-config -n numaplane-system` show `immutable: true` no longer there.

