### PR TITLE
feat: pipeline draining with image tag change

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1085,7 +1085,25 @@ data:
                     - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                       valueFrom:
                         configMapKeyRef:
-                          key: controller.disable.leader.election
+                          key: controller.leader.election.disabled
+                          name: numaflow-cmd-params-config
+                          optional: true
+                    - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+                      valueFrom:
+                        configMapKeyRef:
+                          key: controller.leader.election.lease.duration
+                          name: numaflow-cmd-params-config
+                          optional: true
+                    - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+                      valueFrom:
+                        configMapKeyRef:
+                          key: controller.leader.election.lease.renew.deadline
+                          name: numaflow-cmd-params-config
+                          optional: true
+                    - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+                      valueFrom:
+                        configMapKeyRef:
+                          key: controller.leader.election.lease.renew.period
                           name: numaflow-cmd-params-config
                           optional: true
                   image: quay.io/numaproj/numaflow:latest
@@ -1125,6 +1143,11 @@ data:
         apiVersion: v1
         data:
           controller-config.yaml: |
+            defaults:
+              containerResources: |
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
             isbsvc:
               redis:
                 # Default Redis settings, could be overridden by InterStepBufferService specs
@@ -1154,6 +1177,11 @@ data:
                   redisImage: bitnami/redis:7.0.11-debian-11-r3
                   sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
                   redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+                  initContainerImage: debian:latest
+                - version: 7.0.15
+                  redisImage: bitnami/redis:7.0.15-debian-11-r2
+                  sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+                  redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
                   initContainerImage: debian:latest
               jetstream:
                 # Default JetStream settings, could be overridden by InterStepBufferService specs
@@ -1253,6 +1281,11 @@ data:
                   startCommand: /nats-server
                 - version: 2.10.3
                   natsImage: nats:2.10.3
+                  metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                  configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                  startCommand: /nats-server
+                - version: 2.10.11
+                  natsImage: nats:2.10.11
                   metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
                   configReloaderImage: natsio/nats-server-config-reloader:0.7.0
                   startCommand: /nats-server

--- a/config/manager/numaflow-controller-definitions-config.yaml
+++ b/config/manager/numaflow-controller-definitions-config.yaml
@@ -50,7 +50,25 @@ data:
                     - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                       valueFrom:
                         configMapKeyRef:
-                          key: controller.disable.leader.election
+                          key: controller.leader.election.disabled
+                          name: numaflow-cmd-params-config
+                          optional: true
+                    - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+                      valueFrom:
+                        configMapKeyRef:
+                          key: controller.leader.election.lease.duration
+                          name: numaflow-cmd-params-config
+                          optional: true
+                    - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+                      valueFrom:
+                        configMapKeyRef:
+                          key: controller.leader.election.lease.renew.deadline
+                          name: numaflow-cmd-params-config
+                          optional: true
+                    - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+                      valueFrom:
+                        configMapKeyRef:
+                          key: controller.leader.election.lease.renew.period
                           name: numaflow-cmd-params-config
                           optional: true
                   image: quay.io/numaproj/numaflow:latest
@@ -90,6 +108,11 @@ data:
         apiVersion: v1
         data:
           controller-config.yaml: |
+            defaults:
+              containerResources: |
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
             isbsvc:
               redis:
                 # Default Redis settings, could be overridden by InterStepBufferService specs
@@ -119,6 +142,11 @@ data:
                   redisImage: bitnami/redis:7.0.11-debian-11-r3
                   sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
                   redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+                  initContainerImage: debian:latest
+                - version: 7.0.15
+                  redisImage: bitnami/redis:7.0.15-debian-11-r2
+                  sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+                  redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
                   initContainerImage: debian:latest
               jetstream:
                 # Default JetStream settings, could be overridden by InterStepBufferService specs
@@ -218,6 +246,11 @@ data:
                   startCommand: /nats-server
                 - version: 2.10.3
                   natsImage: nats:2.10.3
+                  metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                  configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                  startCommand: /nats-server
+                - version: 2.10.11
+                  natsImage: nats:2.10.11
                   metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
                   configReloaderImage: natsio/nats-server-config-reloader:0.7.0
                   startCommand: /nats-server

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -18,9 +18,11 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -98,7 +100,7 @@ func (r *PipelineRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	pipelineRollout.Status.InitConditions()
 
-	err := r.reconcile(ctx, pipelineRollout)
+	enqueue, err := r.reconcile(ctx, pipelineRollout)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -122,13 +124,19 @@ func (r *PipelineRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	if enqueue {
+		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+	}
 	numaLogger.Debug("reconciliation successful")
 
 	return ctrl.Result{}, nil
 }
 
 // reconcile does the real logic
-func (r *PipelineRolloutReconciler) reconcile(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
+func (r *PipelineRolloutReconciler) reconcile(
+	ctx context.Context,
+	pipelineRollout *apiv1.PipelineRollout,
+) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 
 	// is PipelineRollout being deleted? need to remove the finalizer so it can
@@ -138,7 +146,7 @@ func (r *PipelineRolloutReconciler) reconcile(ctx context.Context, pipelineRollo
 		if controllerutil.ContainsFinalizer(pipelineRollout, finalizerName) {
 			controllerutil.RemoveFinalizer(pipelineRollout, finalizerName)
 		}
-		return nil
+		return false, nil
 	}
 
 	// add Finalizer so we can ensure that we take appropriate action when CRD is deleted
@@ -146,6 +154,8 @@ func (r *PipelineRolloutReconciler) reconcile(ctx context.Context, pipelineRollo
 		controllerutil.AddFinalizer(pipelineRollout, finalizerName)
 	}
 
+	// if not, check the change if it is image change, if yes, pause
+	// if not, just update
 	// apply Pipeline
 	// todo: store hash of spec in annotation; use to compare to determine if anything needs to be updated
 	obj := kubernetes.GenericObject{
@@ -161,24 +171,80 @@ func (r *PipelineRolloutReconciler) reconcile(ctx context.Context, pipelineRollo
 		Spec: pipelineRollout.Spec.Pipeline,
 	}
 
-	err := kubernetes.ApplyCRSpec(ctx, r.restConfig, &obj, "pipelines")
+	// Get the object to see if it exists
+	_, err := kubernetes.GetResource(ctx, r.restConfig, &obj, "pipelines")
 	if err != nil {
-		numaLogger.Errorf(err, "failed to apply Pipeline: %v", err)
-		pipelineRollout.Status.MarkFailed("ApplyPipelineFailure", err.Error())
-		return err
-	}
-	// after the Apply, Get the Pipeline so that we can propagate its health into our Status
-	pipeline, err := kubernetes.GetCR(ctx, r.restConfig, &obj, "pipelines")
-	if err != nil {
-		numaLogger.Errorf(err, "failed to get Pipeline: %v", err)
-		return err
-	}
+		// create object as it doesn't exist
+		if apierrors.IsNotFound(err) {
+			err = kubernetes.CreateCR(ctx, r.restConfig, &obj, "pipelines")
+			if err != nil {
+				return false, err
+			}
+		}
+	} else {
+		// If the pipeline already exist, first check if the pipeline status
+		// is pausing. If so, re-enqueue immediately.
+		pipeline, err := kubernetes.GetCR(ctx, r.restConfig, &obj, "pipelines")
+		if err != nil {
+			numaLogger.Errorf(err, "failed to get Pipeline: %v", err)
+			return false, err
+		}
+		pausing := isPipelinePausing(ctx, pipeline)
+		if pausing {
+			// re-enqueue
+			return true, nil
+		}
 
-	processPipelineStatus(ctx, pipeline, pipelineRollout)
+		// Check if the pipeline status is paused. If so, apply the change and
+		// resume.
+		paused := isPipelinePaused(ctx, pipeline)
+		if paused {
+			// Apply the new spec and resume the pipeline
+			newObj, err := setPipelineDesiredStatus(&obj, "Running")
+			if err != nil {
+				return false, err
+			}
+			obj = *newObj
+
+			err = applyPipelineSpec(ctx, r.restConfig, &obj, pipelineRollout)
+			if err != nil {
+				return false, err
+			}
+
+			return false, nil
+		}
+
+		// If pipeline status is not above, detect if pausing is required.
+		shouldPause, err := needsPausing(pipeline, &obj)
+		if err != nil {
+			return false, err
+		}
+		if shouldPause {
+			// Use the existing spec, then pausing and re-enqueue
+			obj.Spec = pipeline.Spec
+			newObj, err := setPipelineDesiredStatus(&obj, "Paused")
+			if err != nil {
+				return false, err
+			}
+			obj = *newObj
+
+			err = applyPipelineSpec(ctx, r.restConfig, &obj, pipelineRollout)
+			if err != nil {
+				return false, err
+			}
+			return true, err
+		}
+
+		// If no need to pause, just apply the spec
+		err = applyPipelineSpec(ctx, r.restConfig, &obj, pipelineRollout)
+		if err != nil {
+			return false, err
+		}
+	}
 
 	pipelineRollout.Status.MarkRunning()
 
-	return nil
+	return false, nil
 }
 
 // Set the Condition in the Status for child resource health
@@ -235,4 +301,122 @@ func (r *PipelineRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return nil
+}
+
+func setPipelineDesiredStatus(obj *kubernetes.GenericObject, status string) (*kubernetes.GenericObject, error) {
+	unstruc, err := kubernetes.ObjectToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	err = unstructured.SetNestedField(unstruc.Object, status, "spec", "lifecycle", "desiredPhase")
+	if err != nil {
+		return nil, err
+	}
+
+	newObj, err := kubernetes.UnstructuredToObject(unstruc)
+	if err != nil {
+		return nil, err
+	}
+	return newObj, nil
+}
+
+func isPipelinePausing(ctx context.Context, pipeline *kubernetes.GenericObject) bool {
+	numaLogger := logger.FromContext(ctx)
+	pipelineStatus, err := kubernetes.ParseStatus(pipeline)
+	if err != nil {
+		numaLogger.Errorf(err, "failed to parse Pipeline Status from pipeline CR: %+v, %v", pipeline, err)
+		return false
+	}
+
+	numaLogger.Debugf("pipeline status: %+v", pipelineStatus)
+
+	return numaflowv1.PipelinePhase(pipelineStatus.Phase) == numaflowv1.PipelinePhasePausing
+}
+
+func isPipelinePaused(ctx context.Context, pipeline *kubernetes.GenericObject) bool {
+	numaLogger := logger.FromContext(ctx)
+	pipelineStatus, err := kubernetes.ParseStatus(pipeline)
+	if err != nil {
+		numaLogger.Errorf(err, "failed to parse Pipeline Status from pipeline CR: %+v, %v", pipeline, err)
+		return false
+	}
+
+	numaLogger.Debugf("pipeline status: %+v", pipelineStatus)
+
+	return numaflowv1.PipelinePhase(pipelineStatus.Phase) == numaflowv1.PipelinePhasePaused
+}
+
+func applyPipelineSpec(
+	ctx context.Context,
+	restConfig *rest.Config,
+	obj *kubernetes.GenericObject,
+	pipelineRollout *apiv1.PipelineRollout,
+) error {
+	numaLogger := logger.FromContext(ctx)
+	// TODO: use UpdateSpec instead
+	err := kubernetes.ApplyCRSpec(ctx, restConfig, obj, "pipelines")
+	if err != nil {
+		numaLogger.Errorf(err, "failed to apply Pipeline: %v", err)
+		pipelineRollout.Status.MarkFailed("ApplyPipelineFailure", err.Error())
+		return err
+	}
+	// after the Apply, Get the Pipeline so that we can propagate its health into our Status
+	pipeline, err := kubernetes.GetCR(ctx, restConfig, obj, "pipelines")
+	if err != nil {
+		numaLogger.Errorf(err, "failed to get Pipeline: %v", err)
+		return err
+	}
+
+	processPipelineStatus(ctx, pipeline, pipelineRollout)
+	return nil
+}
+
+// TODO: detect engine
+func needsPausing(obj *kubernetes.GenericObject, newObj *kubernetes.GenericObject) (bool, error) {
+	// only check if image tag changes for now
+	image, found, err := hasUDFImage(obj)
+	if err != nil {
+		return false, err
+	}
+
+	newImage, newFound, err := hasUDFImage(newObj)
+	if err != nil {
+		return false, err
+	}
+
+	// existing has image field, but new does not.
+	// Or if image does not match
+	if found != newFound || *image != *newImage {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func hasUDFImage(obj *kubernetes.GenericObject) (*string, bool, error) {
+	unstruc, err := kubernetes.ObjectToUnstructured(obj)
+	if err != nil {
+		return nil, false, err
+	}
+
+	vertices, found, err := unstructured.NestedSlice(unstruc.Object, "spec", "vertices")
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return nil, false, nil
+	}
+	for _, v := range vertices {
+		vertex := v.(map[string]interface{})
+		// TODO: we need return all, now we only return the first
+		image, found, err := unstructured.NestedString(vertex, "udf", "container", "image")
+		if err != nil {
+			return nil, false, err
+		}
+		if found {
+			return &image, true, nil
+		}
+	}
+	return nil, false, nil
 }

--- a/internal/kubernetes/dynamic_client.go
+++ b/internal/kubernetes/dynamic_client.go
@@ -55,8 +55,34 @@ func ParseStatus(obj *GenericObject) (GenericStatus, error) {
 	return status, nil
 }
 
+func GetResource(
+	ctx context.Context,
+	restConfig *rest.Config,
+	object *GenericObject,
+	pluralName string,
+) (*unstructured.Unstructured, error) {
+	client, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+
+	group, version, err := parseApiVersion(object.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: pluralName,
+	}
+
+	return client.Resource(gvr).Namespace(object.Namespace).Get(ctx, object.Name, v1.GetOptions{})
+}
+
 // ApplyCRSpec either creates or updates an object identified by the RawExtension, using the new definition,
 // first checking to see if there's a difference in Spec before applying
+// TODO: use CreateCR and UpdateCR instead
 func ApplyCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericObject, pluralName string) error {
 	numaLogger := logger.FromContext(ctx)
 
@@ -84,7 +110,7 @@ func ApplyCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericOb
 			// create object as it doesn't exist
 			numaLogger.Debugf("didn't find resource %s/%s, will create", object.Namespace, object.Name)
 
-			unstruct, err := objectToUnstructured(object)
+			unstruct, err := ObjectToUnstructured(object)
 			if err != nil {
 				return err
 			}
@@ -99,7 +125,7 @@ func ApplyCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericOb
 		}
 
 	} else {
-		numaLogger.Debugf("found existing Resource definition for %s/%s: %+v", object.Namespace, object.Name, resource)
+		numaLogger.Debugf(fmt.Sprintf("found existing Resource definition for %s/%s: %+v", object.Namespace, object.Name, resource))
 		// todo:
 		//   If the existing annotation matches the new hash, then nothing to do: log and return
 
@@ -118,14 +144,30 @@ func ApplyCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericOb
 
 // look up a Resource
 func GetCR(ctx context.Context, restConfig *rest.Config, object *GenericObject, pluralName string) (*GenericObject, error) {
+	unstruc, err := GetResource(ctx, restConfig, object, pluralName)
+	if unstruc != nil {
+		return UnstructuredToObject(unstruc)
+	} else {
+		return nil, err
+	}
+}
+
+func CreateCR(
+	ctx context.Context,
+	restConfig *rest.Config,
+	object *GenericObject,
+	pluralName string,
+) error {
+	numaLogger := logger.FromContext(ctx)
+
 	client, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
+		return fmt.Errorf("failed to create dynamic client: %v", err)
 	}
 
 	group, version, err := parseApiVersion(object.APIVersion)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	gvr := schema.GroupVersionResource{
@@ -133,15 +175,23 @@ func GetCR(ctx context.Context, restConfig *rest.Config, object *GenericObject, 
 		Version:  version,
 		Resource: pluralName,
 	}
-	unstruc, err := client.Resource(gvr).Namespace(object.Namespace).Get(ctx, object.Name, v1.GetOptions{})
-	if unstruc != nil {
-		return unstructuredToObject(unstruc)
-	} else {
-		return nil, err
+
+	numaLogger.Debugf("didn't find resource %s/%s, will create", object.Namespace, object.Name)
+
+	unstruct, err := ObjectToUnstructured(object)
+	if err != nil {
+		return err
 	}
+
+	_, err = client.Resource(gvr).Namespace(object.Namespace).Create(ctx, unstruct, v1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create Resource %s/%s, err=%v", object.Namespace, object.Name, err)
+	}
+	numaLogger.Debugf("successfully created resource %s/%s", object.Namespace, object.Name)
+	return nil
 }
 
-func objectToUnstructured(object *GenericObject) (*unstructured.Unstructured, error) {
+func ObjectToUnstructured(object *GenericObject) (*unstructured.Unstructured, error) {
 	asJsonBytes, err := json.Marshal(object)
 	if err != nil {
 		return nil, err
@@ -155,7 +205,7 @@ func objectToUnstructured(object *GenericObject) (*unstructured.Unstructured, er
 	return &unstructured.Unstructured{Object: asMap}, nil
 }
 
-func unstructuredToObject(u *unstructured.Unstructured) (*GenericObject, error) {
+func UnstructuredToObject(u *unstructured.Unstructured) (*GenericObject, error) {
 	asJsonBytes, err := json.Marshal(u.Object)
 	if err != nil {
 		return nil, err

--- a/tests/manifests/controller_definitions.yaml
+++ b/tests/manifests/controller_definitions.yaml
@@ -44,7 +44,25 @@ controllerDefinitions:
                 - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                   valueFrom:
                     configMapKeyRef:
-                      key: controller.disable.leader.election
+                      key: controller.leader.election.disabled
+                      name: numaflow-cmd-params-config
+                      optional: true
+                - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+                  valueFrom:
+                    configMapKeyRef:
+                      key: controller.leader.election.lease.duration
+                      name: numaflow-cmd-params-config
+                      optional: true
+                - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+                  valueFrom:
+                    configMapKeyRef:
+                      key: controller.leader.election.lease.renew.deadline
+                      name: numaflow-cmd-params-config
+                      optional: true
+                - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+                  valueFrom:
+                    configMapKeyRef:
+                      key: controller.leader.election.lease.renew.period
                       name: numaflow-cmd-params-config
                       optional: true
               image: quay.io/numaproj/numaflow:latest
@@ -84,6 +102,11 @@ controllerDefinitions:
     apiVersion: v1
     data:
       controller-config.yaml: |
+        defaults:
+          containerResources: |
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
         isbsvc:
           redis:
             # Default Redis settings, could be overridden by InterStepBufferService specs
@@ -113,6 +136,11 @@ controllerDefinitions:
               redisImage: bitnami/redis:7.0.11-debian-11-r3
               sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
               redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+              initContainerImage: debian:latest
+            - version: 7.0.15
+              redisImage: bitnami/redis:7.0.15-debian-11-r2
+              sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+              redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
               initContainerImage: debian:latest
           jetstream:
             # Default JetStream settings, could be overridden by InterStepBufferService specs
@@ -212,6 +240,11 @@ controllerDefinitions:
               startCommand: /nats-server
             - version: 2.10.3
               natsImage: nats:2.10.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.11
+              natsImage: nats:2.10.11
               metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
               configReloaderImage: natsio/nats-server-config-reloader:0.7.0
               startCommand: /nats-server


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

When pipeline spec is updated with image tag change, pipeline will be paused and drained then the change will be applied and resume the pipeline to avoid data loss.


### Verification

- apply the following PipelineRollout spec,

```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: PipelineRollout
metadata:
  name: my-pipeline
  namespace: example-namespace
spec:
  pipeline:
    interStepBufferServiceName: my-isbsvc
    vertices:
      - name: in
        source:
          # A self data generating source
          generator:
            rpu: 5
            duration: 5s
      - name: even-or-odd
        partitions: 2
        udf:
          container:
            # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
            image: quay.io/numaio/numaflow-go/map-even-odd:numaplane-demo-v1.0.0 # or use image tag map-even-odd:numaplane-demo-v1.0.1
            imagePullPolicy: Always
      - name: even-sink
        partitions: 2
        sink:
          udsink:
            container:
              # A redis sink for e2e testing, see https://github.com/numaproj/numaflow-go/tree/main/pkg/sinker/examples/redis-sink
              image: quay.io/numaio/numaflow-go/redis-sink:stable
              imagePullPolicy: Always
      - name: odd-sink
        sink:
          udsink:
            container:
              image: quay.io/numaio/numaflow-go/redis-sink:stable
              imagePullPolicy: Always
      - name: number-sink
        sink:
          udsink:
            container:
              image: quay.io/numaio/numaflow-go/redis-sink:stable
              imagePullPolicy: Always
    edges:
      - from: in
        to: even-or-odd
      - from: even-or-odd
        to: even-sink
        conditions:
          tags:
            operator: or
            values:
              - even-tag
      - from: even-or-odd
        to: odd-sink
        conditions:
          tags:
            operator: or
            values:
              - odd-tag
      - from: even-or-odd
        to: number-sink
        conditions:
          tags:
            operator: or
            values:
              - odd-tag
              - even-tag
```

- while pipeline is running, change the pipeline spec to  `duration: 1s`. This pipeline spec change will be applied immediately.
- Change the pipeline spec to have `even-or-odd` vertex use a a different image `image: quay.io/numaio/numaflow-go/map-even-odd:numaplane-demo-v1.0.0 # or use image tag map-even-odd:numaplane-demo-v1.0.1` 
- This pipeline spec will trigger a pausing and after data is drained the pipeline spec is updated and resumed to avoid data loss.



